### PR TITLE
[CBRD-23886] Fix jdbc symbolic link error

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -89,5 +89,5 @@ if [ ! -d $shell_dir/output ]; then
 fi
 echo $version > $shell_dir/output/VERSION-DIST
 $ant_file dist-cubrid -buildfile $shell_dir/build.xml -Dbasedir=$shell_dir -Dversion=$version -Dsrc=$shell_dir/src
-ln -sf $shell_dir/JDBC-$version-cubrid.jar $shell_dir/cubrid_jdbc.jar
+ln -sf JDBC-$version-cubrid.jar $shell_dir/cubrid_jdbc.jar
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23886

* The contents of a symbolic link must be a relative name (basename)
  * not of style: /home/kshanrel/1/cubrid/cubrid-jdbc/JDBC-11.1.0.0001-cubrid.jar
  * but **JDBC-11.1.0.0001-cubrid.jar**