### PR TITLE
[CBRD-23912] JDBC version error in coverage build on the QA system

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -73,13 +73,23 @@ fi
 
 # check version
 echo "[INFO] Checking VERSION"
+
 if [ -f $shell_dir/VERSION ]; then
   version_file=VERSION
-  version=$(cat $shell_dir/$version_file)
+elif [ -f $shell_dir/output/VERSION-DIST ]; then   
+  version_file=output/VERSION-DIST
+fi
+
+_version=$(cat $shell_dir/$version_file)
+serial_number=$(echo $_version | cut -d . -f 4)
+if [ "x$serial_number" != "x" ]; then
+  version=$_version
+elif [ -d $shell_dir/.git -o -d $shell_dir/../.git ]; then
   serial_number=$(cd $shell_dir && $which_git rev-list --count --after $serial_start_date HEAD | awk '{ printf "%04d", $1 }' 2> /dev/null)
-  version=$version.$serial_number
-else 
-  version="external"
+  version=$_version.$serial_number
+else
+  serial_number="external"
+  version=$_version.$serial_number
 fi
 
 echo "[INFO] VERSION = $version"

--- a/build.xml
+++ b/build.xml
@@ -46,7 +46,7 @@
         <delete failonerror="false" includeEmptyDirs="true">
             <fileset dir="${bin-cubrid}"/>
             <fileset dir="${src-cubrid}"/>
-            <fileset dir="${output}"/>
+            <fileset dir="${output}" excludes="VERSION-DIST"/>
             <fileset file="${cubrid-jar-file}"/>
             <fileset file="${cubrid-src-jar-file}"/>
             <fileset file="*.jar"/>


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23886

Purpose
In the QA system, there is no .git in the source for coverage builds.
Therefore, a version information file is required when versioning JDBC.

- Related to https://github.com/CUBRID/cubrid/pull/2759