### PR TITLE
[APIS-858] Fix version for google-java-format action

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -79,6 +79,7 @@ jobs:
       - uses: axel-op/googlejavaformat-action@v3
         with:
           skipCommit: true
+          version: 1.7
           args: "--aosp --replace --set-exit-if-changed"
           files: ${{ steps.files.outputs.added_modified }}
       - name: Suggest code changes


### PR DESCRIPTION
http://jira.cubrid.org/browse/APIS-858

Since the cubrid-jdbc is based on JDK 1.6, google-java-format 1.7 should be used.