### PR TITLE
[CBRD-24063] Error occurs when Connection.close() is called multiple times in Server-side JDBC

### DIFF
--- a/src/jdbc/cubrid/jdbc/jci/UServerSideConnection.java
+++ b/src/jdbc/cubrid/jdbc/jci/UServerSideConnection.java
@@ -190,14 +190,17 @@ public class UServerSideConnection extends UConnection {
     protected void closeInternal() {
         if (client != null) {
             stmtHandlerCache.clearStatus();
-            disconnect();
-            UJCIUtil.invoke(
-                    "com.cubrid.jsp.ExecuteThread",
-                    "setStatus",
-                    new Class[] {Integer.class},
-                    this.curThread,
-                    new Object[] {INVOKE});
-        }
+            int currentStatus = (Integer) UJCIUtil.invoke("com.cubrid.jsp.ExecuteThread", "getStatus", new Class[] {}, this.curThread, new Object[] {});
+            if (currentStatus != INVOKE) {
+                disconnect();
+                UJCIUtil.invoke(
+                        "com.cubrid.jsp.ExecuteThread",
+                        "setStatus",
+                        new Class[] {Integer.class},
+                        this.curThread,
+                        new Object[] {INVOKE});
+            }
+       }
     }
 
     @Override

--- a/src/jdbc/cubrid/jdbc/jci/UServerSideConnection.java
+++ b/src/jdbc/cubrid/jdbc/jci/UServerSideConnection.java
@@ -46,7 +46,9 @@ import java.net.Socket;
 import java.util.List;
 
 public class UServerSideConnection extends UConnection {
+    /* defined in ExecuteThreadStatus.java */
     public static final int INVOKE = 2;
+    public static final int CALL = 3;
 
     private static final byte CAS_CLIENT_SERVER_SIDE_JDBC = 6;
 
@@ -191,7 +193,7 @@ public class UServerSideConnection extends UConnection {
         if (client != null) {
             stmtHandlerCache.clearStatus();
             int currentStatus = (Integer) UJCIUtil.invoke("com.cubrid.jsp.ExecuteThread", "getStatus", new Class[] {}, this.curThread, new Object[] {});
-            if (currentStatus != INVOKE) {
+            if (currentStatus == CALL) {
                 disconnect();
                 UJCIUtil.invoke(
                         "com.cubrid.jsp.ExecuteThread",

--- a/src/jdbc/cubrid/jdbc/jci/UServerSideConnection.java
+++ b/src/jdbc/cubrid/jdbc/jci/UServerSideConnection.java
@@ -192,7 +192,14 @@ public class UServerSideConnection extends UConnection {
     protected void closeInternal() {
         if (client != null) {
             stmtHandlerCache.clearStatus();
-            int currentStatus = (Integer) UJCIUtil.invoke("com.cubrid.jsp.ExecuteThread", "getStatus", new Class[] {}, this.curThread, new Object[] {});
+            int currentStatus =
+                    (Integer)
+                            UJCIUtil.invoke(
+                                    "com.cubrid.jsp.ExecuteThread",
+                                    "getStatus",
+                                    new Class[] {},
+                                    this.curThread,
+                                    new Object[] {});
             if (currentStatus == CALL) {
                 disconnect();
                 UJCIUtil.invoke(
@@ -202,7 +209,7 @@ public class UServerSideConnection extends UConnection {
                         this.curThread,
                         new Object[] {INVOKE});
             }
-       }
+        }
     }
 
     @Override


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24063

When entering SP function body in ExecuteThread, The thread has `INVOKE` status. and If Server-side JDBC opens Connection, ExecuteThread has `CALL` status and CAS enters `libcas_main()`. `disconnect()` should be called only when CAS is in CALL state to exit from `libcas_main()`, otherwise it should do nothing. 

```
// ExecuteThread.java
    private void processStoredProcedure() throws Exception {
        ...

        setStatus(ExecuteThreadStatus.INVOKE);
        Object result = m.invoke(null, resolved);

        /* close server-side JDBC connection */
        closeJdbcConnection(); // NOTE: If there is Connection.close() in function body, status is INVOKE. otherwise CALL.

        ...
    }
```
