### PR TITLE
[CBRD-24063] Fix "Cannot communicate with the broker" error

### DIFF
--- a/src/jdbc/cubrid/jdbc/jci/UServerSideConnection.java
+++ b/src/jdbc/cubrid/jdbc/jci/UServerSideConnection.java
@@ -200,7 +200,7 @@ public class UServerSideConnection extends UConnection {
                                     new Class[] {},
                                     this.curThread,
                                     new Object[] {});
-            if (currentStatus == CALL) {
+            if (currentStatus != INVOKE) {
                 disconnect();
                 UJCIUtil.invoke(
                         "com.cubrid.jsp.ExecuteThread",


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24063

This PR fixes regression caused by 3807c2b. In ExecuteThreadStatus.DESTROY status, UServerSideConnection.close(I) also be called, and It causes ""Cannot communicate with the broker"" error at the end of calling Java Stored procdure.