### PR TITLE
[APIS-885] Rollback does not work when using distributed transaction (CUBRIDXAConnection).

### DIFF
--- a/src/jdbc/cubrid/jdbc/driver/CUBRIDConnectionWrapperXA.java
+++ b/src/jdbc/cubrid/jdbc/driver/CUBRIDConnectionWrapperXA.java
@@ -129,6 +129,7 @@ public class CUBRIDConnectionWrapperXA extends CUBRIDConnection {
         if (u != null) {
             u_con = u;
             u_con.setCUBRIDConnection(this);
+            u_con.setAutoCommit(auto_commit);
         }
     }
 
@@ -138,5 +139,6 @@ public class CUBRIDConnectionWrapperXA extends CUBRIDConnection {
         xa_started = false;
         if (u != null) u_con = u;
         auto_commit = true;
+        u_con.setAutoCommit(auto_commit);
     }
 }


### PR DESCRIPTION
http://jira.cubrid.org/browse/APIS-885

**Purpose**
When using distributed transaction, rollback does not work, so data is entered into the DB.
In a distributed transaction, commit and rollback should be performed only through XAResource.

**Implementation**
Changed auto_commit mode to false when starting a distributed transaction.

**Remarks**
N/A