### PR TITLE
[APIS-906] PrepareStmtCache must be maintained until the Connection is closed.

### DIFF
--- a/src/jdbc/cubrid/jdbc/driver/CUBRIDConnection.java
+++ b/src/jdbc/cubrid/jdbc/driver/CUBRIDConnection.java
@@ -705,6 +705,10 @@ public class CUBRIDConnection implements Connection {
         closeAllStatements();
         closeAllOutResultSet();
 
+        if (prepStmtCache != null) {
+            prepStmtCache.clear();
+        }
+
         if (mdata != null) {
             mdata.close();
             mdata = null;

--- a/src/jdbc/cubrid/jdbc/driver/CUBRIDPreparedStatement.java
+++ b/src/jdbc/cubrid/jdbc/driver/CUBRIDPreparedStatement.java
@@ -726,7 +726,7 @@ public class CUBRIDPreparedStatement extends CUBRIDStatement implements Prepared
                     if (u_stmt != null) {
                         String sql = "";
                         sql = u_stmt.getQuery();
-                        if (u_con.isPrepStmtCache(sql)) {
+                        if (con.prepStmtCache.get(sql) != null) {
                             return;
                         }
                     }

--- a/src/jdbc/cubrid/jdbc/driver/CUBRIDPreparedStatement.java
+++ b/src/jdbc/cubrid/jdbc/driver/CUBRIDPreparedStatement.java
@@ -721,22 +721,24 @@ public class CUBRIDPreparedStatement extends CUBRIDStatement implements Prepared
         try {
             synchronized (con) {
                 synchronized (this) {
-                    String sql = "";
-
                     setShardId(UShardInfo.SHARD_ID_INVALID);
+
+                    if (u_stmt != null) {
+                        String sql = "";
+                        sql = u_stmt.getQuery();
+                        if (u_con.isPrepStmtCache(sql)) {
+                            return;
+                        }
+                    }
+
                     if (is_closed) return;
 
                     complete();
                     is_closed = true;
 
                     if (u_stmt != null) {
-                        sql = u_stmt.getQuery();
                         u_stmt.close();
                         u_stmt = null;
-                    }
-
-                    if (u_con.isPrepStmtCache(sql)) {
-                        con.prepStmtCache.remove(sql);
                     }
 
                     con.removeStatement(this);


### PR DESCRIPTION
http://jira.cubrid.org/browse/APIS-906​

Purpose
When using Prepared Statement Cache using usePreparedStmtCache, preparedStmtCacheSize, and preparedStmtCacheSqlLimitYou can use more queries faster. However, when the statement is closed, the cache is deleted, and the prepare step is performed again when performing the same query after that, resulting in a delay in query execution.To eliminate this delay, the cache should be maintained until the connection is closed.  

Implementation
N/A

Remarks
N/A