### PR TITLE
[CBRD-23966] Fix creating cubrid_jdbc.jar symlink as relative path

### DIFF
--- a/cmake/gen_symlink.cmake
+++ b/cmake/gen_symlink.cmake
@@ -23,11 +23,13 @@ endif(NOT CUBRID_JDBC_VERSION)
 
 if(UNIX)
   execute_process(
-    COMMAND ${CMAKE_COMMAND} -E create_symlink ${CUBRID_JDBC_SOURCE_DIR}/JDBC-${CUBRID_JDBC_VERSION}-cubrid.jar ${CUBRID_JDBC_SOURCE_DIR}/cubrid_jdbc.jar
+    COMMAND ${CMAKE_COMMAND} -E create_symlink JDBC-${CUBRID_JDBC_VERSION}-cubrid.jar cubrid_jdbc.jar
+    WORKING_DIRECTORY ${CUBRID_JDBC_SOURCE_DIR}
   )
 else(UNIX)
   execute_process(
-    COMMAND ${CMAKE_COMMAND} -E copy ${CUBRID_JDBC_SOURCE_DIR}/JDBC-${CUBRID_JDBC_VERSION}-cubrid.jar ${CUBRID_JDBC_SOURCE_DIR}/cubrid_jdbc.jar
+    COMMAND ${CMAKE_COMMAND} -E copy JDBC-${CUBRID_JDBC_VERSION}-cubrid.jar cubrid_jdbc.jar
+    WORKING_DIRECTORY ${CUBRID_JDBC_SOURCE_DIR}
   )
 endif(UNIX)
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23966

In the install folder, cubrid_jdbc.jar has an absolute path to the cubrid-jdbc source folder, If the source folder is removed, the symlink is broken.