### PR TITLE
[CBRD-23846] Restore setReturnable () in CUBRIDResultSet for compatibility prior to 11.2

### DIFF
--- a/src/jdbc/cubrid/jdbc/driver/CUBRIDResultSet.java
+++ b/src/jdbc/cubrid/jdbc/driver/CUBRIDResultSet.java
@@ -302,7 +302,7 @@ public class CUBRIDResultSet implements ResultSet {
     }
 
     @Deprecated
-    public void setReturnable () {
+    public void setReturnable() {
         // do nothing
         // This is for compatibility with versions prior to 11.2.
     }

--- a/src/jdbc/cubrid/jdbc/driver/CUBRIDResultSet.java
+++ b/src/jdbc/cubrid/jdbc/driver/CUBRIDResultSet.java
@@ -301,6 +301,12 @@ public class CUBRIDResultSet implements ResultSet {
         return was_null;
     }
 
+    @Deprecated
+    public void setReturnable () {
+        // do nothing
+        // This is for compatibility with versions prior to 11.2.
+    }
+
     public synchronized String getString(int columnIndex) throws SQLException {
         checkIsOpen();
         beforeGetValue(columnIndex);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23846

All versions share the same Java SP functions in `cubrid-testtools`. `setReturnable()` in `CUBRIDResultSet` is required to make test compatible with prior version.