### PR TITLE
[CBRD-23846] Fix broken backward compatibility throwing exception in CUBRIDOutResultSet.createInstance()

### DIFF
--- a/src/jdbc/cubrid/jdbc/driver/CUBRIDOutResultSet.java
+++ b/src/jdbc/cubrid/jdbc/driver/CUBRIDOutResultSet.java
@@ -56,6 +56,9 @@ public class CUBRIDOutResultSet extends CUBRIDResultSet {
 
     public void createInstance() throws Exception {
         if (created) return;
+        if (resultId <= 0) {
+            throw new IllegalArgumentException ();
+        }
 
         u_stmt = new UStatement(ucon, resultId);
         column_info = u_stmt.getColumnInfo();
@@ -65,6 +68,7 @@ public class CUBRIDOutResultSet extends CUBRIDResultSet {
         created = true;
     }
 
+    @Override
     public void close() throws SQLException {
         if (is_closed) {
             return;

--- a/src/jdbc/cubrid/jdbc/driver/CUBRIDOutResultSet.java
+++ b/src/jdbc/cubrid/jdbc/driver/CUBRIDOutResultSet.java
@@ -39,9 +39,9 @@ public class CUBRIDOutResultSet extends CUBRIDResultSet {
     private boolean created;
 
     /*
-    * if under PROTOCOL_V11) SRV_HANDLE id
-    * else) QUERY_ID
-    */
+     * if under PROTOCOL_V11) SRV_HANDLE id
+     * else) QUERY_ID
+     */
     private long resultId;
 
     private UConnection ucon;
@@ -57,7 +57,7 @@ public class CUBRIDOutResultSet extends CUBRIDResultSet {
     public void createInstance() throws Exception {
         if (created) return;
         if (resultId <= 0) {
-            throw new IllegalArgumentException ();
+            throw new IllegalArgumentException();
         }
 
         u_stmt = new UStatement(ucon, resultId);


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23846

At #28, code throwing IllegalArgumentException is omitted, It breaks a unit test related to CUBRIDOutResultSet.