### PR TITLE
[CBRD-24297] jdbc driver fails ot initialize if not built from within valid submodule git repo clone

### DIFF
--- a/cmake/gen_version.cmake
+++ b/cmake/gen_version.cmake
@@ -54,9 +54,10 @@ else(EXISTS ${CUBRID_JDBC_OUTPUT_DIR}/VERSION-DIST AND NOT EXISTS ${CUBRID_JDBC_
     list(GET VERSION_MATCHES 0 EXTRA_VERSION)
     endif (UNIX)
 
-    if(git_result)
-        message(FATAL_ERROR "Could not get count information from Git")
-    endif(git_result)
+    if ("${EXTRA_VERSION}" STREQUAL "")
+       message(WARNING "Could not get count information from Git. So EXTRA_VERSION is 0000")
+       set(EXTRA_VERSION "0000")
+    endif ("${EXTRA_VERSION}" STREQUAL "")
 
     set(CUBRID_JDBC_RELEASE_VERSION ${CUBRID_JDBC_VERSION}.${EXTRA_VERSION})
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24297

- If git information is not exist, The EXTRA VERSION is replaced with 0000.