### PR TITLE
[APIS-886] GeneratedKeys() is supported by cubrid jdbc

### DIFF
--- a/src/jdbc/cubrid/jdbc/driver/CUBRIDDatabaseMetaData.java
+++ b/src/jdbc/cubrid/jdbc/driver/CUBRIDDatabaseMetaData.java
@@ -2534,7 +2534,7 @@ public class CUBRIDDatabaseMetaData implements DatabaseMetaData {
 
     public synchronized boolean supportsGetGeneratedKeys() throws SQLException {
         checkIsOpen();
-        return false;
+        return true;
     }
 
     public synchronized boolean supportsMultipleOpenResults() throws SQLException {


### PR DESCRIPTION
http://jira.cubrid.org/browse/APIS-886

Purpose
In JDBC, GeneratedKeys() works, but supportsGetGeneratedKeys() returns false, so the client can think of it as a function that is not supported.
So, I changed the return value of supportsGetGeneratedKeys() to true.

Implementation
N/A

Remarks
N/A