### PR TITLE
[APIS-961] getObject() also removes zeros below the decimal point of Double and Float values.

### DIFF
--- a/src/jdbc/cubrid/jdbc/jci/UStatement.java
+++ b/src/jdbc/cubrid/jdbc/jci/UStatement.java
@@ -1510,6 +1510,12 @@ public class UStatement {
                 } catch (Exception e) {
                     retValue = null;
                 }
+            } else if (relatedConnection.getOracleStyleNumberReturn() && (obj instanceof Double)) {
+                String numString = obj.toString();
+                retValue = new BigDecimal(numString).stripTrailingZeros().toPlainString();
+            } else if (relatedConnection.getOracleStyleNumberReturn() && (obj instanceof Float)) {
+                String numString = obj.toString();
+                retValue = new BigDecimal(numString).stripTrailingZeros().toPlainString();
             } else retValue = obj;
         } catch (UJciException e) {
             e.toUError(errorHandler);


### PR DESCRIPTION
http://jira.cubrid.org/browse/APIS-961

Purpose
Added to getObject() to remove zeros below the decimal point of double and float values.

Implementation
N/A

Remarks
N/A


