### PR TITLE
[APIS-976] float type precision error

### DIFF
--- a/src/jdbc/cubrid/jdbc/jci/UStatement.java
+++ b/src/jdbc/cubrid/jdbc/jci/UStatement.java
@@ -47,6 +47,7 @@ import cubrid.sql.CUBRIDOID;
 import cubrid.sql.CUBRIDTimestamptz;
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.math.MathContext;
 import java.sql.Blob;
 import java.sql.Clob;
 import java.sql.Date;
@@ -1512,11 +1513,15 @@ public class UStatement {
                 }
             } else if (relatedConnection.isOracleCompatNumberBehavior()
                     && (obj instanceof Double)) {
-                String numString = obj.toString();
-                retValue = new BigDecimal(numString).stripTrailingZeros().toPlainString();
+                retValue =
+                        new BigDecimal(((Number) obj).doubleValue(), MathContext.DECIMAL64)
+                                .stripTrailingZeros()
+                                .toPlainString();
             } else if (relatedConnection.isOracleCompatNumberBehavior() && (obj instanceof Float)) {
-                String numString = obj.toString();
-                retValue = new BigDecimal(numString).stripTrailingZeros().toPlainString();
+                retValue =
+                        new BigDecimal(((Number) obj).floatValue(), MathContext.DECIMAL32)
+                                .stripTrailingZeros()
+                                .toPlainString();
             } else retValue = obj;
         } catch (UJciException e) {
             e.toUError(errorHandler);
@@ -1586,11 +1591,13 @@ public class UStatement {
 
         try {
             if (relatedConnection.isOracleCompatNumberBehavior() && (obj instanceof Double)) {
-                numString = obj.toString();
-                return new BigDecimal(numString).stripTrailingZeros().toPlainString();
+                return new BigDecimal(((Number) obj).doubleValue(), MathContext.DECIMAL64)
+                        .stripTrailingZeros()
+                        .toPlainString();
             } else if (relatedConnection.isOracleCompatNumberBehavior() && (obj instanceof Float)) {
-                numString = obj.toString();
-                return new BigDecimal(numString).stripTrailingZeros().toPlainString();
+                return new BigDecimal(((Number) obj).floatValue(), MathContext.DECIMAL32)
+                        .stripTrailingZeros()
+                        .toPlainString();
             } else {
                 return (UGetTypeConvertedValue.getString(obj));
             }


### PR DESCRIPTION
http://jira.cubrid.org/browse/APIS-976

Purpose
* The input value is 987654321.123, and when oracle=y, the precision of the float type is set to 7 or higher, so the incorrect value of 987654340 is output.
* The precision was changed to 7 so that the value 987654300 was output.

Implementation
N/A

Remarks
N/A