### PR TITLE
[APIS-995] rollback cmake minimum to 2.8

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@
 # 
 #
 
-cmake_minimum_required(VERSION 3.21)
+cmake_minimum_required(VERSION 2.8)
 
 project(CUBRID-JDBC)
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/APIS-995

Purpose
cmake 최소 버전을 2.8 원복 한다.

Implementation
N/A

Remarks
N/A