### PR TITLE
[APIS-1000] Improve ResultSetMetaData return value for multi-schema support

### DIFF
--- a/src/jdbc/cubrid/jdbc/driver/CUBRIDResultSetMetaData.java
+++ b/src/jdbc/cubrid/jdbc/driver/CUBRIDResultSetMetaData.java
@@ -51,6 +51,7 @@ public class CUBRIDResultSetMetaData implements ResultSetMetaData {
     private int[] col_prec;
     private int[] col_disp_size;
     private int[] col_scale;
+    private String[] col_schema;
     private String[] col_table;
     private int[] col_null;
     private String[] col_class_name;
@@ -66,6 +67,7 @@ public class CUBRIDResultSetMetaData implements ResultSetMetaData {
         col_prec = new int[col_info.length];
         col_disp_size = new int[col_info.length];
         col_scale = new int[col_info.length];
+        col_schema = new String[col_info.length];
         col_table = new String[col_info.length];
         col_null = new int[col_info.length];
         col_class_name = new String[col_info.length];
@@ -77,7 +79,10 @@ public class CUBRIDResultSetMetaData implements ResultSetMetaData {
             col_name[i] = col_info[i].getColumnName();
             col_prec[i] = col_info[i].getColumnPrecision();
             col_scale[i] = col_info[i].getColumnScale();
-            col_table[i] = col_info[i].getClassName();
+            String tableName = col_info[i].getClassName();
+            int dotIndex = tableName != null ? tableName.indexOf('.') : -1;
+            col_schema[i] = dotIndex != -1 ? tableName.substring(0, dotIndex) : "";
+            col_table[i] = dotIndex != -1 ? tableName.substring(dotIndex + 1) : tableName;
             col_type_name[i] = null;
             col_class_name[i] = col_info[i].getFQDN();
             if (col_info[i].isNullable()) col_null[i] = columnNullable;
@@ -452,6 +457,7 @@ public class CUBRIDResultSetMetaData implements ResultSetMetaData {
         col_prec = new int[col_name.length];
         col_disp_size = new int[col_name.length];
         col_scale = new int[col_name.length];
+        col_schema = new String[col_name.length];
         col_table = new String[col_name.length];
         col_null = new int[col_name.length];
         col_class_name = new String[col_name.length];
@@ -513,6 +519,7 @@ public class CUBRIDResultSetMetaData implements ResultSetMetaData {
             }
             col_scale[i] = 0;
             ele_type[i] = -1;
+            col_schema[i] = "";
             col_table[i] = "";
             col_charset_name[i] = null;
             if (r.nullable[i]) {
@@ -691,7 +698,7 @@ public class CUBRIDResultSetMetaData implements ResultSetMetaData {
 
     public String getSchemaName(int column) throws SQLException {
         checkColumnIndex(column);
-        return "";
+        return col_schema[column - 1];
     }
 
     public int getPrecision(int column) throws SQLException {


### PR DESCRIPTION
http://jira.cubrid.org/browse/APIS-1000

**Purpose**
ResultSetMetaData 객체의 `getSchemaName()` 메서드는 빈 문자열을 반환하고, `getTableName()` 메서드는 `[schemaName.tableName]` 형식의 문자열을 반환합니다.
멀티 스키마를 지원하는 버전에서는 이러한 동작으로 인해 스키마 이름과 테이블 이름을 명확하게 구분하기 어렵습니다. 이를 개선하기 위해 `getSchemaName()`과 `getTableName()` 메서드의 반환 값을 수정합니다.

**Implementation**
- getSchemaName():
  - 멀티 스키마를 지원하는 경우, 컬럼의 실제 스키마 이름을 반환
  - 멀티 스키마를 지원하지 않는 경우, 빈 문자열 ("") 반환

- getTableName():
  - 스키마 이름을 포함하지 않고, 테이블 이름만 반환하도록 수정

**Remarks**
N/A