### PR TITLE
[APIS-1003] Revert JDBC build Java version to 1.6

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -43,7 +43,7 @@
     </target>
 
     <target name="compile-cubrid" depends="src-jar-cubrid">
-        <javac destdir="${bin-cubrid}" source="1.8" target="1.8" encoding="EUC-KR" debug="true" debuglevel="lines,source,vars" deprecation="off" includeantruntime="no">
+        <javac destdir="${bin-cubrid}" source="1.6" target="1.6" encoding="EUC-KR" debug="true" debuglevel="lines,source,vars" deprecation="off" includeantruntime="no">
             <src path="${src-cubrid}"/>
         </javac>
     </target>


### PR DESCRIPTION
http://jira.cubrid.org/browse/APIS-1003

**Purpose**
build.xml에서 JDBC 빌드 Java 버전을 1.8에서 1.6으로 되돌립니다.

**Implementation**
N/A

**Remarks**
N/A