### PR TITLE
[APIS-1005] Extends the loadBalance Property of JDBC.

### DIFF
--- a/src/jdbc/cubrid/jdbc/driver/CUBRIDDriver.java
+++ b/src/jdbc/cubrid/jdbc/driver/CUBRIDDriver.java
@@ -87,7 +87,7 @@ public class CUBRIDDriver implements Driver {
             "jdbc:cubrid(-oracle|-mysql)?:([a-zA-Z_0-9\\.-]*):([0-9]*):([^:]+):([^:]*):([^:]*):(\\?[a-zA-Z_0-9]+=[^&=?]+(&[a-zA-Z_0-9]+=[^&=?]+)*)?";
     private static final String CUBRID_JDBC_URL_HEADER = "jdbc:cubrid";
     private static final String ENV_JDBC_PROP_NAME = "CUBRID_JDBC_PROP";
-    private int conn_count = 0;
+	private int conn_count = 0;
 
     static {
         try {
@@ -265,19 +265,17 @@ public class CUBRIDDriver implements Driver {
             while (st.hasMoreTokens()) {
                 altHostList.add(st.nextToken());
             }
-
+            
             String loadBalValue = connProperties.getConnLoadBal();
-
-            synchronized (this) {
+            
                 adjustHostList(loadBalValue, altHostList);
                 try {
                     u_con =
                             (UClientSideConnection)
-                                    UJCIManager.connect(altHostList, db, user, pass, resolvedUrl);
+                                    UJCIManager.connect(altHostList, db, user, pass, resolvedUrl);                    
                 } catch (CUBRIDException e) {
                     throw e;
                 }
-            }
         } else {
             try {
                 u_con =
@@ -349,31 +347,25 @@ public class CUBRIDDriver implements Driver {
         File file = new File(filePath);
         return file.exists();
     }
-
+    
     private void adjustHostList(String loadBalValue, ArrayList<String> altHostList) {
-        switch (loadBalValue) {
-            case ConnectionProperties.LB_VAL_TRUE:
-                Collections.shuffle(altHostList);
-                break;
-            case ConnectionProperties.LB_VAL_FALSE:
-                break;
-            case ConnectionProperties.LB_VAL_ROUND_ROBIN:
-                conn_count++;
-                int index =
-                        (conn_count > altHostList.size())
-                                ? (conn_count - 1) % altHostList.size()
-                                : conn_count - 1;
-                Collections.rotate(altHostList, -index);
-
-                if (conn_count >= Integer.MAX_VALUE) {
-                    conn_count = 0;
-                }
-                break;
-            case ConnectionProperties.LB_VAL_SHUFFLE:
-                Collections.shuffle(altHostList);
-                break;
-            default:
-                throw new IllegalArgumentException("Invalid loadBalValue: " + loadBalValue);
+        if ( ConnectionProperties.LB_VAL_TRUE.equals(loadBalValue)) {
+            Collections.shuffle(altHostList);
+        } else if (ConnectionProperties.LB_VAL_ROUND_ROBIN.equals(loadBalValue)) {
+            int count = increment_conn_count();
+            int dist = (count > altHostList.size()) ? (count - 1) % altHostList.size() : count - 1;
+            Collections.rotate(altHostList, -dist);
+        } else if (ConnectionProperties.LB_VAL_SHUFFLE.equals(loadBalValue)) {
+            Collections.shuffle(altHostList);
+		} else if (ConnectionProperties.LB_VAL_FALSE.equals(loadBalValue)) {
+        	// do nothing
+        } else {
+            throw new IllegalArgumentException("Invalid loadBalValue: " + loadBalValue);
         }
+    }
+    
+    private synchronized int increment_conn_count() {
+        conn_count = conn_count + 1;
+        return conn_count;
     }
 }

--- a/src/jdbc/cubrid/jdbc/driver/CUBRIDDriver.java
+++ b/src/jdbc/cubrid/jdbc/driver/CUBRIDDriver.java
@@ -87,7 +87,7 @@ public class CUBRIDDriver implements Driver {
             "jdbc:cubrid(-oracle|-mysql)?:([a-zA-Z_0-9\\.-]*):([0-9]*):([^:]+):([^:]*):([^:]*):(\\?[a-zA-Z_0-9]+=[^&=?]+(&[a-zA-Z_0-9]+=[^&=?]+)*)?";
     private static final String CUBRID_JDBC_URL_HEADER = "jdbc:cubrid";
     private static final String ENV_JDBC_PROP_NAME = "CUBRID_JDBC_PROP";
-	private int conn_count = 0;
+    private int conn_count = 0;
 
     static {
         try {
@@ -265,17 +265,17 @@ public class CUBRIDDriver implements Driver {
             while (st.hasMoreTokens()) {
                 altHostList.add(st.nextToken());
             }
-            
+
             String loadBalValue = connProperties.getConnLoadBal();
-            
-                adjustHostList(loadBalValue, altHostList);
-                try {
-                    u_con =
-                            (UClientSideConnection)
-                                    UJCIManager.connect(altHostList, db, user, pass, resolvedUrl);                    
-                } catch (CUBRIDException e) {
-                    throw e;
-                }
+
+            adjustHostList(loadBalValue, altHostList);
+            try {
+                u_con =
+                        (UClientSideConnection)
+                                UJCIManager.connect(altHostList, db, user, pass, resolvedUrl);
+            } catch (CUBRIDException e) {
+                throw e;
+            }
         } else {
             try {
                 u_con =
@@ -347,23 +347,22 @@ public class CUBRIDDriver implements Driver {
         File file = new File(filePath);
         return file.exists();
     }
-    
+
     private void adjustHostList(String loadBalValue, ArrayList<String> altHostList) {
-        if ( ConnectionProperties.LB_VAL_TRUE.equals(loadBalValue)) {
-            Collections.shuffle(altHostList);
-        } else if (ConnectionProperties.LB_VAL_ROUND_ROBIN.equals(loadBalValue)) {
+        if (ConnectionProperties.LB_VAL_TRUE.equals(loadBalValue)
+                || ConnectionProperties.LB_VAL_ROUND_ROBIN.equals(loadBalValue)) {
             int count = increment_conn_count();
             int dist = (count > altHostList.size()) ? (count - 1) % altHostList.size() : count - 1;
             Collections.rotate(altHostList, -dist);
         } else if (ConnectionProperties.LB_VAL_SHUFFLE.equals(loadBalValue)) {
             Collections.shuffle(altHostList);
-		} else if (ConnectionProperties.LB_VAL_FALSE.equals(loadBalValue)) {
-        	// do nothing
+        } else if (ConnectionProperties.LB_VAL_FALSE.equals(loadBalValue)) {
+            // do nothing
         } else {
             throw new IllegalArgumentException("Invalid loadBalValue: " + loadBalValue);
         }
     }
-    
+
     private synchronized int increment_conn_count() {
         conn_count = conn_count + 1;
         return conn_count;

--- a/src/jdbc/cubrid/jdbc/driver/CUBRIDDriver.java
+++ b/src/jdbc/cubrid/jdbc/driver/CUBRIDDriver.java
@@ -364,7 +364,7 @@ public class CUBRIDDriver implements Driver {
     }
 
     private synchronized int increment_conn_count() {
-        conn_count = conn_count + 1;
+        conn_count = (conn_count >= Integer.MAX_VALUE) ? 1 : conn_count + 1;
         return conn_count;
     }
 }


### PR DESCRIPTION
http://jira.cubrid.org/browse/APIS-1005

Purpose
connection url의 loadBalance property 사용방법을 확장 하였다.
기존 기능에 Round-Robin 방식을 추가함

확장후 loadBalance 사용 방법
loadBalance=true (Round-Robin 방식)
loadBalance=false (기존과 동일, loadBalance 사용안함)
loadBalance=rr (Round-Robin 방식)
loadBalance=sh (Shuffle 방식)

