### PR TITLE
[APIS-1028] Remove double, float conditionals from getObject method

### DIFF
--- a/src/jdbc/cubrid/jdbc/jci/UStatement.java
+++ b/src/jdbc/cubrid/jdbc/jci/UStatement.java
@@ -1511,17 +1511,6 @@ public class UStatement {
                 } catch (Exception e) {
                     retValue = null;
                 }
-            } else if (relatedConnection.isOracleCompatNumberBehavior()
-                    && (obj instanceof Double)) {
-                retValue =
-                        new BigDecimal(((Number) obj).doubleValue(), MathContext.DECIMAL64)
-                                .stripTrailingZeros()
-                                .toPlainString();
-            } else if (relatedConnection.isOracleCompatNumberBehavior() && (obj instanceof Float)) {
-                retValue =
-                        new BigDecimal(((Number) obj).floatValue(), MathContext.DECIMAL32)
-                                .stripTrailingZeros()
-                                .toPlainString();
             } else retValue = obj;
         } catch (UJciException e) {
             e.toUError(errorHandler);


### PR DESCRIPTION
http://jira.cubrid.org/browse/APIS-1028

**Purpose**
CUBRID DOUBLE, FLOAT 타입을 JDBC getObject() 메소드를 통해 조회 시 Java의 Double과 Float 타입으로 반환할 수 있도록 수정합니다.

**Implementation**
UStatement - getObject 메소드의 Double과 Float을 문자열로 변경하는 코드를 제거합니다.

**Remakrs**
삭제하는 코드는 아래 PR에서 추가 되었습니다. 
- #41 
- #42 