### PR TITLE
[APIS-1040] Upgrade cmake minimum version to 3.21

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@
 # 
 #
 
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.21)
 
 project(CUBRID-JDBC)
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/APIS-1040

**Purpose**
- JDBC CMake 최소 버전을 3.21로 변경합니다.

**Implementation**
N/A

**Remarks**
- https://github.com/CUBRID/cubrid/pull/4739
- https://github.com/CUBRID/cubrid/pull/5433