### PR TITLE
[APIS-1041] Standardize JDBC JAR filenames for Maven Central deployment

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -4,8 +4,8 @@
 <project default="dist-cubrid" name="CUBRID JDBC Driver">
     <property name="output" value="${basedir}/output"/>
     <property file="${output}/build.properties" />
-    <property name="cubrid-jar-file" value="${basedir}/JDBC-${version}-cubrid.jar"/>
-    <property name="cubrid-src-jar-file" value="${basedir}/JDBC-${version}-cubrid-src.jar"/>
+    <property name="cubrid-jar-file" value="${basedir}/cubrid-jdbc-${version}.jar"/>
+    <property name="cubrid-src-jar-file" value="${basedir}/cubrid-jdbc-${version}-sources.jar"/>
     <property name="bin-cubrid" location="${output}/bin-cubrid"/>
     <property name="src-cubrid" location="${output}/src-cubrid"/>
     <property name="src" value="${basedir}/src"/>

--- a/cmake/gen_symlink.cmake
+++ b/cmake/gen_symlink.cmake
@@ -23,12 +23,12 @@ endif(NOT CUBRID_JDBC_VERSION)
 
 if(UNIX)
   execute_process(
-    COMMAND ${CMAKE_COMMAND} -E create_symlink JDBC-${CUBRID_JDBC_VERSION}-cubrid.jar cubrid_jdbc.jar
+    COMMAND ${CMAKE_COMMAND} -E create_symlink cubrid-jdbc-${CUBRID_JDBC_VERSION}.jar cubrid_jdbc.jar
     WORKING_DIRECTORY ${CUBRID_JDBC_SOURCE_DIR}
   )
 else(UNIX)
   execute_process(
-    COMMAND ${CMAKE_COMMAND} -E copy JDBC-${CUBRID_JDBC_VERSION}-cubrid.jar cubrid_jdbc.jar
+    COMMAND ${CMAKE_COMMAND} -E copy cubrid-jdbc-${CUBRID_JDBC_VERSION}.jar cubrid_jdbc.jar
     WORKING_DIRECTORY ${CUBRID_JDBC_SOURCE_DIR}
   )
 endif(UNIX)


### PR DESCRIPTION
http://jira.cubrid.org/browse/APIS-1041

### Purpose
- Maven Central에 CUBRID JDBC 드라이버를 등록하기 위해 공식 가이드라인에 맞는 파일명 규칙을 적용합니다.

### Implementation
- build.xml 및 cmake 스크립트에서 생성되는 JAR 파일명을 다음과 같이 수정
  - `cubrid-jdbc-<version>.jar`
  - `cubrid-jdbc-<version>-sources.jar`

### Remarks
- [[APIS-1036] JDBC 공식 Maven Central 등록](http://jira.cubrid.org/browse/APIS-1036)