### PR TITLE
[APIS-1058] Fix broken Korean comments and unify encoding to UTF-8

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -46,14 +46,14 @@
     </target>
 
     <target name="compile-cubrid" depends="src-jar-cubrid">
-        <javac destdir="${bin-cubrid}" source="1.6" target="1.6" encoding="EUC-KR" debug="true" debuglevel="lines,source,vars" deprecation="off" includeantruntime="no">
+        <javac destdir="${bin-cubrid}" source="1.6" target="1.6" encoding="UTF-8" debug="true" debuglevel="lines,source,vars" deprecation="off" includeantruntime="no">
             <src path="${src-cubrid}"/>
         </javac>
     </target>
 
     <target name="doc-jar-cubrid" depends="compile-cubrid">
         <mkdir dir="${doc-cubrid}"/>
-        <javadoc destdir="${doc-cubrid}" sourcepath="${src}/jdbc" author="true" version="true" encoding="EUC-KR" docencoding="EUC-KR" charset="EUC-KR">
+        <javadoc destdir="${doc-cubrid}" sourcepath="${src}/jdbc" author="true" version="true" encoding="UTF-8" docencoding="UTF-8" charset="UTF-8">
             <classpath>
                 <pathelement location="${bin-cubrid}"/>
             </classpath>

--- a/src/jdbc/cubrid/jdbc/jci/CUBRIDCommandType.java
+++ b/src/jdbc/cubrid/jdbc/jci/CUBRIDCommandType.java
@@ -41,7 +41,7 @@
 package cubrid.jdbc.jci;
 
 /**
- * CUBRID�� Command Type�� �����ϴ� class�̴�.
+ * Defines the command types used in CUBRID.
  *
  * <p>since 1.0
  */

--- a/src/jdbc/cubrid/jdbc/jci/CUBRIDIsolationLevel.java
+++ b/src/jdbc/cubrid/jdbc/jci/CUBRIDIsolationLevel.java
@@ -41,7 +41,7 @@
 package cubrid.jdbc.jci;
 
 /**
- * CUBRID�� Isolation level�� ������ class�̴�.
+ * Defines the isolation levels used in CUBRID.
  *
  * <p>since 1.0
  */

--- a/src/jdbc/cubrid/jdbc/jci/USchType.java
+++ b/src/jdbc/cubrid/jdbc/jci/USchType.java
@@ -41,7 +41,7 @@
 package cubrid.jdbc.jci;
 
 /**
- * CUBRID�� Schema type�� �����ϴ� class�̴�.
+ * Defines the schema types used in CUBRID.
  *
  * <p>since 1.0
  */

--- a/src/jdbc/cubrid/jdbc/jci/UUType.java
+++ b/src/jdbc/cubrid/jdbc/jci/UUType.java
@@ -52,7 +52,7 @@ import java.sql.Time;
 import java.sql.Timestamp;
 
 /**
- * CUBRID Data Type�� ������ ���� class�̴�.
+ * Defines the data types used in CUBRID.
  *
  * <p>since 1.0
  */


### PR DESCRIPTION
http://jira.cubrid.org/browse/APIS-1058

### Purpose
기존 JDBC 소스코드는 EUC-KR 인코딩으로 관리되어 왔으며, 일부 주석에 한글이 포함되어 있었습니다. 
CBRD-23885 이슈 처리 과정에서 google-java-format을 적용하면서 파일 인코딩이 UTF-8로 변경되었고, 이로 인해 한글 주석이 깨져 원문 의미를 알기 어렵게 되었습니다.
깨진 한글 주석을 영문으로 변경하고, 빌드 및 Javadoc 생성 시 인코딩을 UTF-8로 통일합니다.

### Implementation
- build.xml 컴파일 및 Javadoc 인코딩 설정 EUC-KR -> UTF-8 변경

### Remarks
- #2 