### PR TITLE
[APIS-1074] Error handing for after_next()

### DIFF
--- a/src/jdbc/cubrid/jdbc/driver/CUBRIDResultSet.java
+++ b/src/jdbc/cubrid/jdbc/driver/CUBRIDResultSet.java
@@ -257,6 +257,25 @@ public class CUBRIDResultSet implements ResultSet {
             return false;
         }
 
+        int errorCode = error.getErrorCode();
+        if (errorCode < 0) {
+            switch (errorCode) {
+                case UErrorCode.ER_DBMS:
+                case UErrorCode.ER_COMMUNICATION:
+                case UErrorCode.ER_ILLEGAL_DATA_SIZE:
+                case UErrorCode.CAS_ER_DBMS:
+                case UErrorCode.CAS_ER_COMMUNICATION:
+                    synchronized (u_stmt) {
+                        u_stmt.closeResult();
+                    }
+                    current_row = 0;
+                    is_closed = true;
+                    throw con.createCUBRIDException(error);
+                default:
+                    break;
+            }
+        }
+
         return true;
     }
 

--- a/src/jdbc/cubrid/jdbc/driver/CUBRIDResultSet.java
+++ b/src/jdbc/cubrid/jdbc/driver/CUBRIDResultSet.java
@@ -258,7 +258,7 @@ public class CUBRIDResultSet implements ResultSet {
         }
 
         int errorCode = error.getErrorCode();
-        if (errorCode < 0) {
+        if (errorCode != UErrorCode.ER_NO_ERROR) {
             switch (errorCode) {
                 case UErrorCode.ER_DBMS:
                 case UErrorCode.ER_COMMUNICATION:


### PR DESCRIPTION
http://jira.cubrid.org/browse/APIS-1074

Purpose
next() 함수 사용 시 Critical 한 Error 사항에 대해서만 Resultset을 정리하고 Exception을 반환하도록 수정합니다.
(관련 이슈 : http://jira.cubrid.org/browse/CBRD-26218)

Implementation
- Close the result set and throw 'Excpetion' if fetch fails in after()