### PR TITLE
[APIS-1077] Use google-java-format 1.7 from CUBRID/3rdparty

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -71,19 +71,33 @@ jobs:
   code-style:
     name: code-style
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
-      - uses: actions/checkout@v2
-      - id: files
-        uses: jitterbit/get-changed-files@v1
-        continue-on-error: true
-      - uses: axel-op/googlejavaformat-action@v3
+      - uses: actions/checkout@v4
         with:
-          skipCommit: true
-          version: 1.7
-          args: "--aosp --replace --set-exit-if-changed"
-          files: ${{ steps.files.outputs.added_modified }}
+          fetch-depth: 0
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '8'
+      - name: Download google-java-format 1.7
+        run: |
+          wget -q -O "$RUNNER_TEMP/gjf.jar" \
+            https://github.com/CUBRID/3rdparty/raw/develop/google-java-format/google-java-format-1.7-all-deps.jar
+      - id: changed
+        uses: tj-actions/changed-files@24d32ffd492484c1d75e0c0b894501ddb9d30d62
+        with:
+          files: "**/*.java"
+          write_output_files: true
+      - name: Run google-java-format 1.7 on changed files
+        if: ${{ steps.changed.outputs.any_changed == 'true' }}
+        run: |
+            echo "Running google-java-format on changed files..."
+            java -jar "$RUNNER_TEMP/gjf.jar" \
+              --aosp --replace --set-exit-if-changed @.github/outputs/all_changed_files.txt
       - name: Suggest code changes
         if: ${{ failure() }}
-        uses: reviewdog/action-suggester@v1
+        uses: reviewdog/action-suggester@aa38384ceb608d00f84b4690cacc83a5aba307ff
         with:
           tool_name: code-style (indent, googlejavaformat)


### PR DESCRIPTION
http://jira.cubrid.org/browse/APIS-1077

### Purpose
https://github.com/CUBRID/3rdparty/tree/develop/google-java-format 에 있는 `google-java-format-1.7-all-deps.jar `을 사용하도록 수정합니다. 

### Implementation
N/A

### Remarks
N/A