### PR TITLE
[APIS-1083] Change build.xml compile source/target from 1.6 to 1.8

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -46,7 +46,7 @@
     </target>
 
     <target name="compile-cubrid" depends="src-jar-cubrid">
-        <javac destdir="${bin-cubrid}" source="1.6" target="1.6" encoding="UTF-8" debug="true" debuglevel="lines,source,vars" deprecation="off" includeantruntime="no">
+        <javac destdir="${bin-cubrid}" source="1.8" target="1.8" encoding="UTF-8" debug="true" debuglevel="lines,source,vars" deprecation="off" includeantruntime="no">
             <src path="${src-cubrid}"/>
         </javac>
     </target>


### PR DESCRIPTION
http://jira.cubrid.org/browse/APIS-1083

### Purpose
JDBC API 4.2 스펙 확장을 위해 컴파일 호환 레벨을 1.8로 변경합니다.
이 변경으로 JDBC는 Java 1.8(major version 52) 바이트코드로 빌드됩니다.

### Implementation
N/A

### Remarks
N/A