### PR TITLE
[APIS-1087] Fix NPE on connection-less ResultSet

### DIFF
--- a/src/jdbc/cubrid/jdbc/driver/CUBRIDOutResultSet.java
+++ b/src/jdbc/cubrid/jdbc/driver/CUBRIDOutResultSet.java
@@ -47,7 +47,7 @@ public class CUBRIDOutResultSet extends CUBRIDResultSet {
     private UConnection ucon;
 
     public CUBRIDOutResultSet(UConnection ucon, long id) {
-        super(null);
+        super(ucon.getCUBRIDConnection(), null);
         created = false;
         this.resultId = id;
         this.ucon = ucon;

--- a/src/jdbc/cubrid/jdbc/driver/CUBRIDResultSet.java
+++ b/src/jdbc/cubrid/jdbc/driver/CUBRIDResultSet.java
@@ -155,8 +155,8 @@ public class CUBRIDResultSet implements ResultSet {
         }
     }
 
-    public CUBRIDResultSet(UStatement s) {
-        con = null;
+    public CUBRIDResultSet(CUBRIDConnection c, UStatement s) {
+        con = c;
         stmt = null;
         u_stmt = s;
         current_row = -1;

--- a/src/jdbc/cubrid/jdbc/driver/CUBRIDStatement.java
+++ b/src/jdbc/cubrid/jdbc/driver/CUBRIDStatement.java
@@ -596,7 +596,7 @@ public class CUBRIDStatement implements Statement {
         checkIsOpen();
 
         if (auto_generatedkeys_result_set == null) {
-            auto_generatedkeys_result_set = new CUBRIDResultSet(null);
+            auto_generatedkeys_result_set = new CUBRIDResultSet(con, null);
         }
 
         return auto_generatedkeys_result_set;
@@ -965,7 +965,7 @@ public class CUBRIDStatement implements Statement {
                 throw con.createCUBRIDException(error);
         }
 
-        auto_generatedkeys_result_set = new CUBRIDResultSet(auto_generatedkeys_stmt);
+        auto_generatedkeys_result_set = new CUBRIDResultSet(con, auto_generatedkeys_stmt);
 
         return true;
     }

--- a/src/jdbc/cubrid/sql/CUBRIDOIDImpl.java
+++ b/src/jdbc/cubrid/sql/CUBRIDOIDImpl.java
@@ -83,7 +83,7 @@ public class CUBRIDOIDImpl implements CUBRIDOID {
         }
 
         checkError();
-        return new CUBRIDResultSet(u_stmt);
+        return new CUBRIDResultSet(cur_con, u_stmt);
     }
 
     public synchronized void setValues(String[] attrNames, Object[] values) throws SQLException {


### PR DESCRIPTION
http://jira.cubrid.org/browse/APIS-1087

## Purpose
`getGeneratedKeys()`, 저장 프로시저 OUT 커서, `CUBRIDOID.getValues()`가 반환하는 ResultSet은 저수준 `CUBRIDResultSet(UStatement)` 생성자로 만들어져 `con`(연결 참조)이 null로 초기화됩니다.
드라이버는 오류를 `con.createCUBRIDException(...)`으로 만들기 때문에, 이런 ResultSet에서 오류를 알려야하는 상황이 되면 명확한 `SQLException` 대신 `NullPointerException`을 던집니다.

## Implementation
 - 1-arg 생성자 `CUBRIDResultSet(UStatement)`에 `CUBRIDConnection` 파라미터를 추가하고 `con`을 채움

## Remarks
- TC: https://github.com/CUBRID/cubrid-testcases-private/pull/1614