### PR TITLE
[APIS-1091] Implement JDBC 4.2 SQLType overloads by delegation

### DIFF
--- a/src/jdbc/cubrid/jdbc/driver/CUBRIDCallableStatement.java
+++ b/src/jdbc/cubrid/jdbc/driver/CUBRIDCallableStatement.java
@@ -827,12 +827,19 @@ public class CUBRIDCallableStatement extends CUBRIDPreparedStatement implements 
         registerOutParameter(parameterIndex, checkSqlType(sqlType));
     }
 
+    /* As with the int-based overload, scale is ignored. */
     @Override
     public void registerOutParameter(int parameterIndex, SQLType sqlType, int scale)
             throws SQLException {
         registerOutParameter(parameterIndex, checkSqlType(sqlType), scale);
     }
 
+    /*
+     * As with the int-based overload, typeName is ignored: the JDBC spec allows a
+     * driver that does not need the type name information to ignore it, and it
+     * applies only to user-defined (STRUCT/DISTINCT/JAVA_OBJECT) and REF
+     * parameters, which CUBRID does not support.
+     */
     @Override
     public void registerOutParameter(int parameterIndex, SQLType sqlType, String typeName)
             throws SQLException {

--- a/src/jdbc/cubrid/jdbc/driver/CUBRIDCallableStatement.java
+++ b/src/jdbc/cubrid/jdbc/driver/CUBRIDCallableStatement.java
@@ -48,6 +48,7 @@ import java.sql.Ref;
 import java.sql.ResultSet;
 import java.sql.RowId;
 import java.sql.SQLException;
+import java.sql.SQLType;
 import java.sql.SQLXML;
 import java.sql.Statement;
 import java.sql.Time;
@@ -817,5 +818,24 @@ public class CUBRIDCallableStatement extends CUBRIDPreparedStatement implements 
     /* JDK 1.7 */
     public <T> T getObject(String parameterName, Class<T> type) throws SQLException {
         throw new SQLException(new UnsupportedOperationException());
+    }
+
+    // ------------------------- JDBC 4.2 -----------------------------------
+
+    @Override
+    public void registerOutParameter(int parameterIndex, SQLType sqlType) throws SQLException {
+        registerOutParameter(parameterIndex, checkSqlType(sqlType));
+    }
+
+    @Override
+    public void registerOutParameter(int parameterIndex, SQLType sqlType, int scale)
+            throws SQLException {
+        registerOutParameter(parameterIndex, checkSqlType(sqlType), scale);
+    }
+
+    @Override
+    public void registerOutParameter(int parameterIndex, SQLType sqlType, String typeName)
+            throws SQLException {
+        registerOutParameter(parameterIndex, checkSqlType(sqlType), typeName);
     }
 }

--- a/src/jdbc/cubrid/jdbc/driver/CUBRIDPreparedStatement.java
+++ b/src/jdbc/cubrid/jdbc/driver/CUBRIDPreparedStatement.java
@@ -58,6 +58,7 @@ import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.RowId;
 import java.sql.SQLException;
+import java.sql.SQLType;
 import java.sql.SQLXML;
 import java.sql.Statement;
 import java.sql.Time;
@@ -1038,5 +1039,33 @@ public class CUBRIDPreparedStatement extends CUBRIDStatement implements Prepared
     /* JDK 1.6 */
     public void setSQLXML(int parameterIndex, SQLXML xmlObject) throws SQLException {
         throw new SQLException(new java.lang.UnsupportedOperationException());
+    }
+
+    // ------------------------- JDBC 4.2 -----------------------------------
+
+    protected int checkSqlType(SQLType targetSqlType) throws SQLException {
+        if (targetSqlType == null) {
+            throw con.createCUBRIDException(
+                    CUBRIDJDBCErrorCode.invalid_value, " - targetSqlType is null", null);
+        }
+        Integer vendorTypeNumber = targetSqlType.getVendorTypeNumber();
+        if (vendorTypeNumber == null) {
+            throw con.createCUBRIDException(
+                    CUBRIDJDBCErrorCode.invalid_value,
+                    " - targetSqlType has no vendor type number: " + targetSqlType.getName(),
+                    null);
+        }
+        return vendorTypeNumber;
+    }
+
+    @Override
+    public void setObject(int parameterIndex, Object x, SQLType targetSqlType) throws SQLException {
+        setObject(parameterIndex, x, checkSqlType(targetSqlType));
+    }
+
+    @Override
+    public void setObject(int parameterIndex, Object x, SQLType targetSqlType, int scaleOrLength)
+            throws SQLException {
+        setObject(parameterIndex, x, checkSqlType(targetSqlType), scaleOrLength);
     }
 }

--- a/src/jdbc/cubrid/jdbc/driver/CUBRIDPreparedStatement.java
+++ b/src/jdbc/cubrid/jdbc/driver/CUBRIDPreparedStatement.java
@@ -1059,12 +1059,14 @@ public class CUBRIDPreparedStatement extends CUBRIDStatement implements Prepared
     }
 
     @Override
-    public void setObject(int parameterIndex, Object x, SQLType targetSqlType) throws SQLException {
+    public synchronized void setObject(int parameterIndex, Object x, SQLType targetSqlType)
+            throws SQLException {
         setObject(parameterIndex, x, checkSqlType(targetSqlType));
     }
 
     @Override
-    public void setObject(int parameterIndex, Object x, SQLType targetSqlType, int scaleOrLength)
+    public synchronized void setObject(
+            int parameterIndex, Object x, SQLType targetSqlType, int scaleOrLength)
             throws SQLException {
         setObject(parameterIndex, x, checkSqlType(targetSqlType), scaleOrLength);
     }

--- a/src/jdbc/cubrid/jdbc/driver/CUBRIDResultSet.java
+++ b/src/jdbc/cubrid/jdbc/driver/CUBRIDResultSet.java
@@ -53,6 +53,7 @@ import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.RowId;
 import java.sql.SQLException;
+import java.sql.SQLType;
 import java.sql.SQLWarning;
 import java.sql.SQLXML;
 import java.sql.Statement;
@@ -2112,5 +2113,50 @@ public class CUBRIDResultSet implements ResultSet {
     /* JDK 1.7 */
     public <T> T getObject(String columnLabel, Class<T> type) throws SQLException {
         throw new SQLException(new java.lang.UnsupportedOperationException());
+    }
+
+    // ------------------------- JDBC 4.2 -----------------------------------
+
+    private void checkSqlType(SQLType targetSqlType) throws SQLException {
+        if (targetSqlType == null) {
+            throw con.createCUBRIDException(
+                    CUBRIDJDBCErrorCode.invalid_value, " - targetSqlType is null", null);
+        }
+        if (targetSqlType.getVendorTypeNumber() == null) {
+            throw con.createCUBRIDException(
+                    CUBRIDJDBCErrorCode.invalid_value,
+                    " - targetSqlType has no vendor type number: " + targetSqlType.getName(),
+                    null);
+        }
+    }
+
+    @Override
+    public synchronized void updateObject(int columnIndex, Object x, SQLType targetSqlType)
+            throws SQLException {
+        checkSqlType(targetSqlType);
+        updateObject(columnIndex, x);
+    }
+
+    @Override
+    public synchronized void updateObject(
+            int columnIndex, Object x, SQLType targetSqlType, int scaleOrLength)
+            throws SQLException {
+        checkSqlType(targetSqlType);
+        updateObject(columnIndex, x, scaleOrLength);
+    }
+
+    @Override
+    public synchronized void updateObject(String columnLabel, Object x, SQLType targetSqlType)
+            throws SQLException {
+        checkSqlType(targetSqlType);
+        updateObject(columnLabel, x);
+    }
+
+    @Override
+    public synchronized void updateObject(
+            String columnLabel, Object x, SQLType targetSqlType, int scaleOrLength)
+            throws SQLException {
+        checkSqlType(targetSqlType);
+        updateObject(columnLabel, x, scaleOrLength);
     }
 }


### PR DESCRIPTION
http://jira.cubrid.org/browse/APIS-1091

## Purpose
JDBC 4.2에는 파라미터/컬럼 타입을 int 상수 대신 java.sql.SQLType으로 넘기는 오버로드가 있는데, 드라이버에 안 만들어져 있어서 호출하면 바로 SQLFeatureNotSupportedException이 납니다. 이 SQLType 오버로드 9개를 기존 int 기반 메서드에 위임으로 채웠습니다. 

## Implementation
index 기반 오버로드만 세 클래스에 추가
 - CUBRIDPrepareStatement: setObject(SQLType) 2개 + checkSqlType 헬퍼
 - CUBRIDCallableStatement: registerOutParameter(SQLType) 3개 (checkSqlType 상속)
 - CUBRIDResultSet: updateObject(SQLType) 4개

## Remarks
이름 기반 오버로드(setObject(String, ...), registerOutParameter(String, ...)는 기존 메서드도 구현되어 있지 않아 이번 작업에서 제외했습니다.
 - https://github.com/CUBRID/cubrid-testcases-private/pull/1617