### PR TITLE
[APIS-1098] Implement the JDBC Wrapper interface across driver classes

### DIFF
--- a/src/jdbc/cubrid/jdbc/driver/CUBRIDConnection.java
+++ b/src/jdbc/cubrid/jdbc/driver/CUBRIDConnection.java
@@ -1096,10 +1096,6 @@ public class CUBRIDConnection implements Connection {
     @Override
     public boolean isWrapperFor(Class<?> iface) throws SQLException {
         checkIsOpen();
-        if (iface == null) {
-            throw new CUBRIDException(
-                    CUBRIDJDBCErrorCode.invalid_value, CUBRIDException.nullTypeMessage(), null);
-        }
         return iface.isAssignableFrom(getClass());
     }
 
@@ -1107,10 +1103,6 @@ public class CUBRIDConnection implements Connection {
     @Override
     public <T> T unwrap(Class<T> iface) throws SQLException {
         checkIsOpen();
-        if (iface == null) {
-            throw new CUBRIDException(
-                    CUBRIDJDBCErrorCode.invalid_value, CUBRIDException.nullTypeMessage(), null);
-        }
         if (iface.isAssignableFrom(getClass())) {
             return iface.cast(this);
         }

--- a/src/jdbc/cubrid/jdbc/driver/CUBRIDConnection.java
+++ b/src/jdbc/cubrid/jdbc/driver/CUBRIDConnection.java
@@ -1096,17 +1096,25 @@ public class CUBRIDConnection implements Connection {
     @Override
     public boolean isWrapperFor(Class<?> iface) throws SQLException {
         checkIsOpen();
-        return iface != null && iface.isAssignableFrom(getClass());
+        if (iface == null) {
+            throw new CUBRIDException(
+                    CUBRIDJDBCErrorCode.invalid_value, CUBRIDException.nullTypeMessage(), null);
+        }
+        return iface.isAssignableFrom(getClass());
     }
 
     /* JDK 1.6 */
     @Override
     public <T> T unwrap(Class<T> iface) throws SQLException {
         checkIsOpen();
-        if (iface != null && iface.isAssignableFrom(getClass())) {
+        if (iface == null) {
+            throw new CUBRIDException(
+                    CUBRIDJDBCErrorCode.invalid_value, CUBRIDException.nullTypeMessage(), null);
+        }
+        if (iface.isAssignableFrom(getClass())) {
             return iface.cast(this);
         }
-        throw createCUBRIDException(
+        throw new CUBRIDException(
                 CUBRIDJDBCErrorCode.invalid_value,
                 CUBRIDException.cannotUnwrapMessage(iface),
                 null);

--- a/src/jdbc/cubrid/jdbc/driver/CUBRIDConnection.java
+++ b/src/jdbc/cubrid/jdbc/driver/CUBRIDConnection.java
@@ -1093,13 +1093,23 @@ public class CUBRIDConnection implements Connection {
     }
 
     /* JDK 1.6 */
-    public boolean isWrapperFor(Class<?> arg0) throws SQLException {
-        throw new SQLException(new java.lang.UnsupportedOperationException());
+    @Override
+    public boolean isWrapperFor(Class<?> iface) throws SQLException {
+        checkIsOpen();
+        return iface != null && iface.isAssignableFrom(getClass());
     }
 
     /* JDK 1.6 */
-    public <T> T unwrap(Class<T> arg0) throws SQLException {
-        throw new SQLException(new java.lang.UnsupportedOperationException());
+    @Override
+    public <T> T unwrap(Class<T> iface) throws SQLException {
+        checkIsOpen();
+        if (iface != null && iface.isAssignableFrom(getClass())) {
+            return iface.cast(this);
+        }
+        throw createCUBRIDException(
+                CUBRIDJDBCErrorCode.invalid_value,
+                CUBRIDException.cannotUnwrapMessage(iface),
+                null);
     }
 
     /* JDK 1.7 */

--- a/src/jdbc/cubrid/jdbc/driver/CUBRIDDataSource.java
+++ b/src/jdbc/cubrid/jdbc/driver/CUBRIDDataSource.java
@@ -129,13 +129,21 @@ public class CUBRIDDataSource extends CUBRIDDataSourceBase
     }
 
     /* JDK 1.6 */
+    @Override
     public boolean isWrapperFor(Class<?> iface) throws SQLException {
-        throw new SQLException(new java.lang.UnsupportedOperationException());
+        return iface != null && iface.isAssignableFrom(getClass());
     }
 
     /* JDK 1.6 */
+    @Override
     public <T> T unwrap(Class<T> iface) throws SQLException {
-        throw new SQLException(new java.lang.UnsupportedOperationException());
+        if (iface != null && iface.isAssignableFrom(getClass())) {
+            return iface.cast(this);
+        }
+        throw new CUBRIDException(
+                CUBRIDJDBCErrorCode.invalid_value,
+                CUBRIDException.cannotUnwrapMessage(iface),
+                null);
     }
 
     /* JDK 1.7 */

--- a/src/jdbc/cubrid/jdbc/driver/CUBRIDDataSource.java
+++ b/src/jdbc/cubrid/jdbc/driver/CUBRIDDataSource.java
@@ -131,13 +131,21 @@ public class CUBRIDDataSource extends CUBRIDDataSourceBase
     /* JDK 1.6 */
     @Override
     public boolean isWrapperFor(Class<?> iface) throws SQLException {
-        return iface != null && iface.isAssignableFrom(getClass());
+        if (iface == null) {
+            throw new CUBRIDException(
+                    CUBRIDJDBCErrorCode.invalid_value, CUBRIDException.nullTypeMessage(), null);
+        }
+        return iface.isAssignableFrom(getClass());
     }
 
     /* JDK 1.6 */
     @Override
     public <T> T unwrap(Class<T> iface) throws SQLException {
-        if (iface != null && iface.isAssignableFrom(getClass())) {
+        if (iface == null) {
+            throw new CUBRIDException(
+                    CUBRIDJDBCErrorCode.invalid_value, CUBRIDException.nullTypeMessage(), null);
+        }
+        if (iface.isAssignableFrom(getClass())) {
             return iface.cast(this);
         }
         throw new CUBRIDException(

--- a/src/jdbc/cubrid/jdbc/driver/CUBRIDDataSource.java
+++ b/src/jdbc/cubrid/jdbc/driver/CUBRIDDataSource.java
@@ -131,20 +131,12 @@ public class CUBRIDDataSource extends CUBRIDDataSourceBase
     /* JDK 1.6 */
     @Override
     public boolean isWrapperFor(Class<?> iface) throws SQLException {
-        if (iface == null) {
-            throw new CUBRIDException(
-                    CUBRIDJDBCErrorCode.invalid_value, CUBRIDException.nullTypeMessage(), null);
-        }
         return iface.isAssignableFrom(getClass());
     }
 
     /* JDK 1.6 */
     @Override
     public <T> T unwrap(Class<T> iface) throws SQLException {
-        if (iface == null) {
-            throw new CUBRIDException(
-                    CUBRIDJDBCErrorCode.invalid_value, CUBRIDException.nullTypeMessage(), null);
-        }
         if (iface.isAssignableFrom(getClass())) {
             return iface.cast(this);
         }

--- a/src/jdbc/cubrid/jdbc/driver/CUBRIDDatabaseMetaData.java
+++ b/src/jdbc/cubrid/jdbc/driver/CUBRIDDatabaseMetaData.java
@@ -2924,10 +2924,6 @@ public class CUBRIDDatabaseMetaData implements DatabaseMetaData {
     @Override
     public boolean isWrapperFor(Class<?> iface) throws SQLException {
         checkIsOpen();
-        if (iface == null) {
-            throw new CUBRIDException(
-                    CUBRIDJDBCErrorCode.invalid_value, CUBRIDException.nullTypeMessage(), null);
-        }
         return iface.isAssignableFrom(getClass());
     }
 
@@ -2935,10 +2931,6 @@ public class CUBRIDDatabaseMetaData implements DatabaseMetaData {
     @Override
     public <T> T unwrap(Class<T> iface) throws SQLException {
         checkIsOpen();
-        if (iface == null) {
-            throw new CUBRIDException(
-                    CUBRIDJDBCErrorCode.invalid_value, CUBRIDException.nullTypeMessage(), null);
-        }
         if (iface.isAssignableFrom(getClass())) {
             return iface.cast(this);
         }

--- a/src/jdbc/cubrid/jdbc/driver/CUBRIDDatabaseMetaData.java
+++ b/src/jdbc/cubrid/jdbc/driver/CUBRIDDatabaseMetaData.java
@@ -2924,17 +2924,25 @@ public class CUBRIDDatabaseMetaData implements DatabaseMetaData {
     @Override
     public boolean isWrapperFor(Class<?> iface) throws SQLException {
         checkIsOpen();
-        return iface != null && iface.isAssignableFrom(getClass());
+        if (iface == null) {
+            throw new CUBRIDException(
+                    CUBRIDJDBCErrorCode.invalid_value, CUBRIDException.nullTypeMessage(), null);
+        }
+        return iface.isAssignableFrom(getClass());
     }
 
     /* JDK 1.6 */
     @Override
     public <T> T unwrap(Class<T> iface) throws SQLException {
         checkIsOpen();
-        if (iface != null && iface.isAssignableFrom(getClass())) {
+        if (iface == null) {
+            throw new CUBRIDException(
+                    CUBRIDJDBCErrorCode.invalid_value, CUBRIDException.nullTypeMessage(), null);
+        }
+        if (iface.isAssignableFrom(getClass())) {
             return iface.cast(this);
         }
-        throw con.createCUBRIDException(
+        throw new CUBRIDException(
                 CUBRIDJDBCErrorCode.invalid_value,
                 CUBRIDException.cannotUnwrapMessage(iface),
                 null);

--- a/src/jdbc/cubrid/jdbc/driver/CUBRIDDatabaseMetaData.java
+++ b/src/jdbc/cubrid/jdbc/driver/CUBRIDDatabaseMetaData.java
@@ -2921,13 +2921,23 @@ public class CUBRIDDatabaseMetaData implements DatabaseMetaData {
     }
 
     /* JDK 1.6 */
+    @Override
     public boolean isWrapperFor(Class<?> iface) throws SQLException {
-        throw new SQLException(new java.lang.UnsupportedOperationException());
+        checkIsOpen();
+        return iface != null && iface.isAssignableFrom(getClass());
     }
 
     /* JDK 1.6 */
+    @Override
     public <T> T unwrap(Class<T> iface) throws SQLException {
-        throw new SQLException(new java.lang.UnsupportedOperationException());
+        checkIsOpen();
+        if (iface != null && iface.isAssignableFrom(getClass())) {
+            return iface.cast(this);
+        }
+        throw con.createCUBRIDException(
+                CUBRIDJDBCErrorCode.invalid_value,
+                CUBRIDException.cannotUnwrapMessage(iface),
+                null);
     }
 
     /* JDK 1.7 */

--- a/src/jdbc/cubrid/jdbc/driver/CUBRIDException.java
+++ b/src/jdbc/cubrid/jdbc/driver/CUBRIDException.java
@@ -89,6 +89,14 @@ public class CUBRIDException extends SQLException {
      * Pairs with CUBRIDJDBCErrorCode.invalid_value.
      */
     static String cannotUnwrapMessage(Class<?> iface) {
-        return " - cannot unwrap to " + (iface == null ? "null" : iface.getName());
+        return " - cannot unwrap to " + iface.getName();
+    }
+
+    /*
+     * Builds the reason message for a null type argument passed to isWrapperFor or unwrap.
+     * Pairs with CUBRIDJDBCErrorCode.invalid_value.
+     */
+    static String nullTypeMessage() {
+        return " - type must not be null";
     }
 }

--- a/src/jdbc/cubrid/jdbc/driver/CUBRIDException.java
+++ b/src/jdbc/cubrid/jdbc/driver/CUBRIDException.java
@@ -83,4 +83,12 @@ public class CUBRIDException extends SQLException {
                 null,
                 CUBRIDJDBCErrorCode.not_supported);
     }
+
+    /*
+     * Builds the reason message for an unwrap request that this object cannot satisfy.
+     * Pairs with CUBRIDJDBCErrorCode.invalid_value.
+     */
+    static String cannotUnwrapMessage(Class<?> iface) {
+        return " - cannot unwrap to " + (iface == null ? "null" : iface.getName());
+    }
 }

--- a/src/jdbc/cubrid/jdbc/driver/CUBRIDException.java
+++ b/src/jdbc/cubrid/jdbc/driver/CUBRIDException.java
@@ -91,12 +91,4 @@ public class CUBRIDException extends SQLException {
     static String cannotUnwrapMessage(Class<?> iface) {
         return " - cannot unwrap to " + iface.getName();
     }
-
-    /*
-     * Builds the reason message for a null type argument passed to isWrapperFor or unwrap.
-     * Pairs with CUBRIDJDBCErrorCode.invalid_value.
-     */
-    static String nullTypeMessage() {
-        return " - type must not be null";
-    }
 }

--- a/src/jdbc/cubrid/jdbc/driver/CUBRIDResultSet.java
+++ b/src/jdbc/cubrid/jdbc/driver/CUBRIDResultSet.java
@@ -2103,17 +2103,25 @@ public class CUBRIDResultSet implements ResultSet {
     @Override
     public boolean isWrapperFor(Class<?> iface) throws SQLException {
         checkIsOpen();
-        return iface != null && iface.isAssignableFrom(getClass());
+        if (iface == null) {
+            throw new CUBRIDException(
+                    CUBRIDJDBCErrorCode.invalid_value, CUBRIDException.nullTypeMessage(), null);
+        }
+        return iface.isAssignableFrom(getClass());
     }
 
     /* JDK 1.6 */
     @Override
     public <T> T unwrap(Class<T> iface) throws SQLException {
         checkIsOpen();
-        if (iface != null && iface.isAssignableFrom(getClass())) {
+        if (iface == null) {
+            throw new CUBRIDException(
+                    CUBRIDJDBCErrorCode.invalid_value, CUBRIDException.nullTypeMessage(), null);
+        }
+        if (iface.isAssignableFrom(getClass())) {
             return iface.cast(this);
         }
-        throw con.createCUBRIDException(
+        throw new CUBRIDException(
                 CUBRIDJDBCErrorCode.invalid_value,
                 CUBRIDException.cannotUnwrapMessage(iface),
                 null);

--- a/src/jdbc/cubrid/jdbc/driver/CUBRIDResultSet.java
+++ b/src/jdbc/cubrid/jdbc/driver/CUBRIDResultSet.java
@@ -2100,13 +2100,23 @@ public class CUBRIDResultSet implements ResultSet {
     }
 
     /* JDK 1.6 */
+    @Override
     public boolean isWrapperFor(Class<?> iface) throws SQLException {
-        throw new SQLException(new java.lang.UnsupportedOperationException());
+        checkIsOpen();
+        return iface != null && iface.isAssignableFrom(getClass());
     }
 
     /* JDK 1.6 */
+    @Override
     public <T> T unwrap(Class<T> iface) throws SQLException {
-        throw new SQLException(new java.lang.UnsupportedOperationException());
+        checkIsOpen();
+        if (iface != null && iface.isAssignableFrom(getClass())) {
+            return iface.cast(this);
+        }
+        throw con.createCUBRIDException(
+                CUBRIDJDBCErrorCode.invalid_value,
+                CUBRIDException.cannotUnwrapMessage(iface),
+                null);
     }
 
     /* JDK 1.7 */

--- a/src/jdbc/cubrid/jdbc/driver/CUBRIDResultSet.java
+++ b/src/jdbc/cubrid/jdbc/driver/CUBRIDResultSet.java
@@ -2103,10 +2103,6 @@ public class CUBRIDResultSet implements ResultSet {
     @Override
     public boolean isWrapperFor(Class<?> iface) throws SQLException {
         checkIsOpen();
-        if (iface == null) {
-            throw new CUBRIDException(
-                    CUBRIDJDBCErrorCode.invalid_value, CUBRIDException.nullTypeMessage(), null);
-        }
         return iface.isAssignableFrom(getClass());
     }
 
@@ -2114,10 +2110,6 @@ public class CUBRIDResultSet implements ResultSet {
     @Override
     public <T> T unwrap(Class<T> iface) throws SQLException {
         checkIsOpen();
-        if (iface == null) {
-            throw new CUBRIDException(
-                    CUBRIDJDBCErrorCode.invalid_value, CUBRIDException.nullTypeMessage(), null);
-        }
         if (iface.isAssignableFrom(getClass())) {
             return iface.cast(this);
         }

--- a/src/jdbc/cubrid/jdbc/driver/CUBRIDResultSetMetaData.java
+++ b/src/jdbc/cubrid/jdbc/driver/CUBRIDResultSetMetaData.java
@@ -785,13 +785,21 @@ public class CUBRIDResultSetMetaData implements ResultSetMetaData {
     /* JDK 1.6 */
     @Override
     public boolean isWrapperFor(Class<?> iface) throws SQLException {
-        return iface != null && iface.isAssignableFrom(getClass());
+        if (iface == null) {
+            throw new CUBRIDException(
+                    CUBRIDJDBCErrorCode.invalid_value, CUBRIDException.nullTypeMessage(), null);
+        }
+        return iface.isAssignableFrom(getClass());
     }
 
     /* JDK 1.6 */
     @Override
     public <T> T unwrap(Class<T> iface) throws SQLException {
-        if (iface != null && iface.isAssignableFrom(getClass())) {
+        if (iface == null) {
+            throw new CUBRIDException(
+                    CUBRIDJDBCErrorCode.invalid_value, CUBRIDException.nullTypeMessage(), null);
+        }
+        if (iface.isAssignableFrom(getClass())) {
             return iface.cast(this);
         }
         throw new CUBRIDException(

--- a/src/jdbc/cubrid/jdbc/driver/CUBRIDResultSetMetaData.java
+++ b/src/jdbc/cubrid/jdbc/driver/CUBRIDResultSetMetaData.java
@@ -785,20 +785,12 @@ public class CUBRIDResultSetMetaData implements ResultSetMetaData {
     /* JDK 1.6 */
     @Override
     public boolean isWrapperFor(Class<?> iface) throws SQLException {
-        if (iface == null) {
-            throw new CUBRIDException(
-                    CUBRIDJDBCErrorCode.invalid_value, CUBRIDException.nullTypeMessage(), null);
-        }
         return iface.isAssignableFrom(getClass());
     }
 
     /* JDK 1.6 */
     @Override
     public <T> T unwrap(Class<T> iface) throws SQLException {
-        if (iface == null) {
-            throw new CUBRIDException(
-                    CUBRIDJDBCErrorCode.invalid_value, CUBRIDException.nullTypeMessage(), null);
-        }
         if (iface.isAssignableFrom(getClass())) {
             return iface.cast(this);
         }

--- a/src/jdbc/cubrid/jdbc/driver/CUBRIDResultSetMetaData.java
+++ b/src/jdbc/cubrid/jdbc/driver/CUBRIDResultSetMetaData.java
@@ -82,7 +82,10 @@ public class CUBRIDResultSetMetaData implements ResultSetMetaData {
             col_scale[i] = col_info[i].getColumnScale();
             String tableName = col_info[i].getClassName();
             int dotIndex = tableName != null ? tableName.indexOf('.') : -1;
-            col_schema[i] = dotIndex != -1 ? tableName.substring(0, dotIndex).toUpperCase(Locale.ENGLISH) : "";
+            col_schema[i] =
+                    dotIndex != -1
+                            ? tableName.substring(0, dotIndex).toUpperCase(Locale.ENGLISH)
+                            : "";
             col_table[i] = dotIndex != -1 ? tableName.substring(dotIndex + 1) : tableName;
             col_type_name[i] = null;
             col_class_name[i] = col_info[i].getFQDN();
@@ -780,13 +783,21 @@ public class CUBRIDResultSetMetaData implements ResultSetMetaData {
     }
 
     /* JDK 1.6 */
+    @Override
     public boolean isWrapperFor(Class<?> iface) throws SQLException {
-        throw new SQLException(new java.lang.UnsupportedOperationException());
+        return iface != null && iface.isAssignableFrom(getClass());
     }
 
     /* JDK 1.6 */
+    @Override
     public <T> T unwrap(Class<T> iface) throws SQLException {
-        throw new SQLException(new java.lang.UnsupportedOperationException());
+        if (iface != null && iface.isAssignableFrom(getClass())) {
+            return iface.cast(this);
+        }
+        throw new CUBRIDException(
+                CUBRIDJDBCErrorCode.invalid_value,
+                CUBRIDException.cannotUnwrapMessage(iface),
+                null);
     }
 
     private void checkColumnIndex(int column) throws SQLException {

--- a/src/jdbc/cubrid/jdbc/driver/CUBRIDResultSetWithoutQuery.java
+++ b/src/jdbc/cubrid/jdbc/driver/CUBRIDResultSetWithoutQuery.java
@@ -1219,10 +1219,6 @@ class CUBRIDResultSetWithoutQuery implements ResultSet {
     @Override
     public boolean isWrapperFor(Class<?> iface) throws SQLException {
         checkIsOpen();
-        if (iface == null) {
-            throw new CUBRIDException(
-                    CUBRIDJDBCErrorCode.invalid_value, CUBRIDException.nullTypeMessage(), null);
-        }
         return iface.isAssignableFrom(getClass());
     }
 
@@ -1230,10 +1226,6 @@ class CUBRIDResultSetWithoutQuery implements ResultSet {
     @Override
     public <T> T unwrap(Class<T> iface) throws SQLException {
         checkIsOpen();
-        if (iface == null) {
-            throw new CUBRIDException(
-                    CUBRIDJDBCErrorCode.invalid_value, CUBRIDException.nullTypeMessage(), null);
-        }
         if (iface.isAssignableFrom(getClass())) {
             return iface.cast(this);
         }

--- a/src/jdbc/cubrid/jdbc/driver/CUBRIDResultSetWithoutQuery.java
+++ b/src/jdbc/cubrid/jdbc/driver/CUBRIDResultSetWithoutQuery.java
@@ -1219,14 +1219,22 @@ class CUBRIDResultSetWithoutQuery implements ResultSet {
     @Override
     public boolean isWrapperFor(Class<?> iface) throws SQLException {
         checkIsOpen();
-        return iface != null && iface.isAssignableFrom(getClass());
+        if (iface == null) {
+            throw new CUBRIDException(
+                    CUBRIDJDBCErrorCode.invalid_value, CUBRIDException.nullTypeMessage(), null);
+        }
+        return iface.isAssignableFrom(getClass());
     }
 
     /* JDK 1.6 */
     @Override
     public <T> T unwrap(Class<T> iface) throws SQLException {
         checkIsOpen();
-        if (iface != null && iface.isAssignableFrom(getClass())) {
+        if (iface == null) {
+            throw new CUBRIDException(
+                    CUBRIDJDBCErrorCode.invalid_value, CUBRIDException.nullTypeMessage(), null);
+        }
+        if (iface.isAssignableFrom(getClass())) {
             return iface.cast(this);
         }
         throw new CUBRIDException(

--- a/src/jdbc/cubrid/jdbc/driver/CUBRIDResultSetWithoutQuery.java
+++ b/src/jdbc/cubrid/jdbc/driver/CUBRIDResultSetWithoutQuery.java
@@ -1216,13 +1216,23 @@ class CUBRIDResultSetWithoutQuery implements ResultSet {
     }
 
     /* JDK 1.6 */
+    @Override
     public boolean isWrapperFor(Class<?> iface) throws SQLException {
-        throw new SQLException(new java.lang.UnsupportedOperationException());
+        checkIsOpen();
+        return iface != null && iface.isAssignableFrom(getClass());
     }
 
     /* JDK 1.6 */
+    @Override
     public <T> T unwrap(Class<T> iface) throws SQLException {
-        throw new SQLException(new java.lang.UnsupportedOperationException());
+        checkIsOpen();
+        if (iface != null && iface.isAssignableFrom(getClass())) {
+            return iface.cast(this);
+        }
+        throw new CUBRIDException(
+                CUBRIDJDBCErrorCode.invalid_value,
+                CUBRIDException.cannotUnwrapMessage(iface),
+                null);
     }
 
     /* JDK 1.7 */

--- a/src/jdbc/cubrid/jdbc/driver/CUBRIDStatement.java
+++ b/src/jdbc/cubrid/jdbc/driver/CUBRIDStatement.java
@@ -766,13 +766,23 @@ public class CUBRIDStatement implements Statement {
     }
 
     /* JDK 1.6 */
+    @Override
     public boolean isWrapperFor(Class<?> iface) throws SQLException {
-        throw new SQLException(new java.lang.UnsupportedOperationException());
+        checkIsOpen();
+        return iface != null && iface.isAssignableFrom(getClass());
     }
 
     /* JDK 1.6 */
+    @Override
     public <T> T unwrap(Class<T> iface) throws SQLException {
-        throw new SQLException(new java.lang.UnsupportedOperationException());
+        checkIsOpen();
+        if (iface != null && iface.isAssignableFrom(getClass())) {
+            return iface.cast(this);
+        }
+        throw con.createCUBRIDException(
+                CUBRIDJDBCErrorCode.invalid_value,
+                CUBRIDException.cannotUnwrapMessage(iface),
+                null);
     }
 
     protected CUBRIDOID executeInsertCore() throws SQLException {

--- a/src/jdbc/cubrid/jdbc/driver/CUBRIDStatement.java
+++ b/src/jdbc/cubrid/jdbc/driver/CUBRIDStatement.java
@@ -769,17 +769,25 @@ public class CUBRIDStatement implements Statement {
     @Override
     public boolean isWrapperFor(Class<?> iface) throws SQLException {
         checkIsOpen();
-        return iface != null && iface.isAssignableFrom(getClass());
+        if (iface == null) {
+            throw new CUBRIDException(
+                    CUBRIDJDBCErrorCode.invalid_value, CUBRIDException.nullTypeMessage(), null);
+        }
+        return iface.isAssignableFrom(getClass());
     }
 
     /* JDK 1.6 */
     @Override
     public <T> T unwrap(Class<T> iface) throws SQLException {
         checkIsOpen();
-        if (iface != null && iface.isAssignableFrom(getClass())) {
+        if (iface == null) {
+            throw new CUBRIDException(
+                    CUBRIDJDBCErrorCode.invalid_value, CUBRIDException.nullTypeMessage(), null);
+        }
+        if (iface.isAssignableFrom(getClass())) {
             return iface.cast(this);
         }
-        throw con.createCUBRIDException(
+        throw new CUBRIDException(
                 CUBRIDJDBCErrorCode.invalid_value,
                 CUBRIDException.cannotUnwrapMessage(iface),
                 null);

--- a/src/jdbc/cubrid/jdbc/driver/CUBRIDStatement.java
+++ b/src/jdbc/cubrid/jdbc/driver/CUBRIDStatement.java
@@ -769,10 +769,6 @@ public class CUBRIDStatement implements Statement {
     @Override
     public boolean isWrapperFor(Class<?> iface) throws SQLException {
         checkIsOpen();
-        if (iface == null) {
-            throw new CUBRIDException(
-                    CUBRIDJDBCErrorCode.invalid_value, CUBRIDException.nullTypeMessage(), null);
-        }
         return iface.isAssignableFrom(getClass());
     }
 
@@ -780,10 +776,6 @@ public class CUBRIDStatement implements Statement {
     @Override
     public <T> T unwrap(Class<T> iface) throws SQLException {
         checkIsOpen();
-        if (iface == null) {
-            throw new CUBRIDException(
-                    CUBRIDJDBCErrorCode.invalid_value, CUBRIDException.nullTypeMessage(), null);
-        }
         if (iface.isAssignableFrom(getClass())) {
             return iface.cast(this);
         }


### PR DESCRIPTION
http://jira.cubrid.org/browse/APIS-1098

### Purpose
CUBRID JDBC의 고유 API(`getQueryplan`, `setLockTimeout` 등)는 `CUBRIDConnection` 등으로 캐스팅해야 사용할 수 있습니다. HikariCP 같은 풀은 커넥션을 프록시로 감싸서 돌려주므로 직접 캐시팅하면 ClassCastException이 발생합니다. JDBC 4.0의 `java.sql.Wrapper`가 이 문제를 해결해주는 API로, 두 메서드를 구현해 CUBRID 고유 API에 접근할 수 있도록 합니다.

### Implementation
`Wrapper` 직접 구현 7개 클래스.

| 호출 | 결과 |
|---|---|
| 자기 타입 / 구현 인터페이스 | `unwrap` 자신 반환, `isWrapperFor` true |
| 무관한 타입 | `unwrap` SQLException(-21120), `isWrapperFor` false |
| null | 둘 다 NullPointerException (별도 null 검사 없음) |
| 닫힌 객체 | 각 클래스의 기존 closed 예외 |

 - null은 주요 드라이버 5개(pgjdbc, MySQL, Oracle, MariaDB, MSSQL)이 모두 가드 없이 NPE를 던져 동일하게 맞췄습니다.
 - 예외 메시지는 CUBRIDException의 static 헬퍼 cannotUnwrapMessage로 통일했습니다.

### Remarks
- https://github.com/CUBRID/cubrid-testcases-private/pull/1629