### PR TITLE
[APIS-1107] Support java.time types when storing and reading data values

### DIFF
--- a/src/jdbc/cubrid/jdbc/driver/CUBRIDCallableStatement.java
+++ b/src/jdbc/cubrid/jdbc/driver/CUBRIDCallableStatement.java
@@ -817,7 +817,70 @@ public class CUBRIDCallableStatement extends CUBRIDPreparedStatement implements 
 
     /* JDK 1.7 */
     public <T> T getObject(int parameterIndex, Class<T> type) throws SQLException {
-        throw CUBRIDException.notSupported();
+        checkIsOpen();
+        if (type == null) {
+            throw con.createCUBRIDException(
+                    CUBRIDJDBCErrorCode.invalid_value, CUBRIDException.nullTypeMessage(), null);
+        }
+
+        if (type == String.class) {
+            return type.cast(getString(parameterIndex));
+        }
+        if (type == BigDecimal.class) {
+            return type.cast(getBigDecimal(parameterIndex));
+        }
+        if (type == byte[].class) {
+            return type.cast(getBytes(parameterIndex));
+        }
+        if (type == Date.class) {
+            return type.cast(getDate(parameterIndex));
+        }
+        if (type == Time.class) {
+            return type.cast(getTime(parameterIndex));
+        }
+        if (type == Timestamp.class) {
+            return type.cast(getTimestamp(parameterIndex));
+        }
+        if (type == Blob.class) {
+            return type.cast(getBlob(parameterIndex));
+        }
+        if (type == Clob.class) {
+            return type.cast(getClob(parameterIndex));
+        }
+
+        if (type == Boolean.class) {
+            boolean value = getBoolean(parameterIndex);
+            return wasNull() ? null : type.cast(value);
+        }
+        if (type == Byte.class) {
+            byte value = getByte(parameterIndex);
+            return wasNull() ? null : type.cast(value);
+        }
+        if (type == Short.class) {
+            short value = getShort(parameterIndex);
+            return wasNull() ? null : type.cast(value);
+        }
+        if (type == Integer.class) {
+            int value = getInt(parameterIndex);
+            return wasNull() ? null : type.cast(value);
+        }
+        if (type == Long.class) {
+            long value = getLong(parameterIndex);
+            return wasNull() ? null : type.cast(value);
+        }
+        if (type == Float.class) {
+            float value = getFloat(parameterIndex);
+            return wasNull() ? null : type.cast(value);
+        }
+        if (type == Double.class) {
+            double value = getDouble(parameterIndex);
+            return wasNull() ? null : type.cast(value);
+        }
+
+        throw con.createCUBRIDException(
+                CUBRIDJDBCErrorCode.invalid_value,
+                CUBRIDException.cannotConvertMessage(type),
+                null);
     }
 
     /* JDK 1.7 */

--- a/src/jdbc/cubrid/jdbc/driver/CUBRIDCallableStatement.java
+++ b/src/jdbc/cubrid/jdbc/driver/CUBRIDCallableStatement.java
@@ -53,6 +53,9 @@ import java.sql.SQLXML;
 import java.sql.Statement;
 import java.sql.Time;
 import java.sql.Timestamp;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.Calendar;
 import java.util.Map;
 
@@ -609,6 +612,45 @@ public class CUBRIDCallableStatement extends CUBRIDPreparedStatement implements 
         checkBindError();
     }
 
+    private LocalDate getLocalDate(int index) throws SQLException {
+        checkIsOpen();
+        beforeGetValue(index);
+
+        LocalDate value;
+        synchronized (u_stmt) {
+            value = u_stmt.getLocalDate(index);
+            error = u_stmt.getRecentError();
+        }
+        checkGetXXXError();
+        return value;
+    }
+
+    private LocalTime getLocalTime(int index) throws SQLException {
+        checkIsOpen();
+        beforeGetValue(index);
+
+        LocalTime value;
+        synchronized (u_stmt) {
+            value = u_stmt.getLocalTime(index);
+            error = u_stmt.getRecentError();
+        }
+        checkGetXXXError();
+        return value;
+    }
+
+    private LocalDateTime getLocalDateTime(int index) throws SQLException {
+        checkIsOpen();
+        beforeGetValue(index);
+
+        LocalDateTime value;
+        synchronized (u_stmt) {
+            value = u_stmt.getLocalDateTime(index);
+            error = u_stmt.getRecentError();
+        }
+        checkGetXXXError();
+        return value;
+    }
+
     private void beforeGetValue(int index) throws SQLException {
         if (index < 0 || index > u_stmt.getParameterCount()) {
             throw con.createCUBRIDException(CUBRIDJDBCErrorCode.invalid_index, null);
@@ -875,6 +917,16 @@ public class CUBRIDCallableStatement extends CUBRIDPreparedStatement implements 
         if (type == Double.class) {
             double value = getDouble(parameterIndex);
             return wasNull() ? null : type.cast(value);
+        }
+
+        if (type == LocalDate.class) {
+            return type.cast(getLocalDate(parameterIndex));
+        }
+        if (type == LocalTime.class) {
+            return type.cast(getLocalTime(parameterIndex));
+        }
+        if (type == LocalDateTime.class) {
+            return type.cast(getLocalDateTime(parameterIndex));
         }
 
         throw con.createCUBRIDException(

--- a/src/jdbc/cubrid/jdbc/driver/CUBRIDException.java
+++ b/src/jdbc/cubrid/jdbc/driver/CUBRIDException.java
@@ -91,4 +91,12 @@ public class CUBRIDException extends SQLException {
     static String cannotUnwrapMessage(Class<?> iface) {
         return " - cannot unwrap to " + iface.getName();
     }
+
+    static String nullTypeMessage() {
+        return " - type is null";
+    }
+
+    static String cannotConvertMessage(Class<?> type) {
+        return " - cannot convert to " + type.getName();
+    }
 }

--- a/src/jdbc/cubrid/jdbc/driver/CUBRIDException.java
+++ b/src/jdbc/cubrid/jdbc/driver/CUBRIDException.java
@@ -78,25 +78,34 @@ public class CUBRIDException extends SQLException {
      * the driver's own reason message and error code (not_supported).
      */
     static SQLFeatureNotSupportedException notSupported() {
+        return notSupported("");
+    }
+
+    /* As notSupported(), with a reason saying what in particular was refused. */
+    static SQLFeatureNotSupportedException notSupported(String reason) {
         return new SQLFeatureNotSupportedException(
-                CUBRIDJDBCErrorCode.getMessage(CUBRIDJDBCErrorCode.not_supported),
+                CUBRIDJDBCErrorCode.getMessage(CUBRIDJDBCErrorCode.not_supported) + reason,
                 null,
                 CUBRIDJDBCErrorCode.not_supported);
     }
 
     /*
-     * Builds the reason message for an unwrap request that this object cannot satisfy.
-     * Pairs with CUBRIDJDBCErrorCode.invalid_value.
+     * Reason messages. The caller supplies the error code, so the pairing lives here: the store
+     * message goes with not_supported, the other three with invalid_value.
      */
+    static String cannotStoreMessage(Class<?> type) {
+        return " - cannot store " + type.getName();
+    }
+
     static String cannotUnwrapMessage(Class<?> iface) {
         return " - cannot unwrap to " + iface.getName();
     }
 
-    static String nullTypeMessage() {
-        return " - type is null";
-    }
-
     static String cannotConvertMessage(Class<?> type) {
         return " - cannot convert to " + type.getName();
+    }
+
+    static String nullTypeMessage() {
+        return " - type is null";
     }
 }

--- a/src/jdbc/cubrid/jdbc/driver/CUBRIDPreparedStatement.java
+++ b/src/jdbc/cubrid/jdbc/driver/CUBRIDPreparedStatement.java
@@ -63,6 +63,9 @@ import java.sql.SQLXML;
 import java.sql.Statement;
 import java.sql.Time;
 import java.sql.Timestamp;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.Calendar;
 
 /**
@@ -415,6 +418,8 @@ public class CUBRIDPreparedStatement extends CUBRIDStatement implements Prepared
         } else if (x instanceof Clob) {
             setClob(parameterIndex, (Clob) x);
             return;
+        } else if (setJavaTimeObject(parameterIndex, x)) {
+            return;
         }
 
         checkIsOpen();
@@ -456,8 +461,71 @@ public class CUBRIDPreparedStatement extends CUBRIDStatement implements Prepared
         } else if (x instanceof Clob) {
             setClob(parameterIndex, (Clob) x);
             return;
+        } else if (setJavaTimeObject(parameterIndex, x)) {
+            return;
         }
 
+        checkIsOpen();
+        synchronized (u_stmt) {
+            u_stmt.bind(parameterIndex - 1, x);
+            error = u_stmt.getRecentError();
+        }
+        checkBindError();
+    }
+
+    /*
+     * Binds x when it is a java.time value and answers whether it did, so that setObject falls
+     * through for everything else.
+     */
+    private boolean setJavaTimeObject(int parameterIndex, Object x) throws SQLException {
+        if (x instanceof LocalDate) {
+            setLocalDate(parameterIndex, (LocalDate) x);
+        } else if (x instanceof LocalTime) {
+            setLocalTime(parameterIndex, (LocalTime) x);
+        } else if (x instanceof LocalDateTime) {
+            setLocalDateTime(parameterIndex, (LocalDateTime) x);
+        } else if (isUnsupportedJavaTime(x)) {
+            checkIsOpen();
+            throw CUBRIDException.notSupported(CUBRIDException.cannotStoreMessage(x.getClass()));
+        } else {
+            return false;
+        }
+        return true;
+    }
+
+    /* Several java.time types are not Temporal, so an instanceof Temporal guard would miss them. */
+    static boolean isUnsupportedJavaTime(Object x) {
+        return x != null
+                && x.getClass().getName().startsWith("java.time.")
+                && !(x instanceof LocalDate)
+                && !(x instanceof LocalTime)
+                && !(x instanceof LocalDateTime);
+    }
+
+    /*
+     * These three exist to pick the matching UStatement.bind overload. Binding through
+     * bind(int, Object) would not do: overloads are chosen from the static type, and
+     * UUType.getObjectDBtype has no java.time arm, so the bind would fail as an invalid argument.
+     */
+    private void setLocalDate(int parameterIndex, LocalDate x) throws SQLException {
+        checkIsOpen();
+        synchronized (u_stmt) {
+            u_stmt.bind(parameterIndex - 1, x);
+            error = u_stmt.getRecentError();
+        }
+        checkBindError();
+    }
+
+    private void setLocalTime(int parameterIndex, LocalTime x) throws SQLException {
+        checkIsOpen();
+        synchronized (u_stmt) {
+            u_stmt.bind(parameterIndex - 1, x);
+            error = u_stmt.getRecentError();
+        }
+        checkBindError();
+    }
+
+    private void setLocalDateTime(int parameterIndex, LocalDateTime x) throws SQLException {
         checkIsOpen();
         synchronized (u_stmt) {
             u_stmt.bind(parameterIndex - 1, x);

--- a/src/jdbc/cubrid/jdbc/driver/CUBRIDResultSet.java
+++ b/src/jdbc/cubrid/jdbc/driver/CUBRIDResultSet.java
@@ -2120,13 +2120,76 @@ public class CUBRIDResultSet implements ResultSet {
     }
 
     /* JDK 1.7 */
-    public <T> T getObject(int columnIndex, Class<T> type) throws SQLException {
-        throw CUBRIDException.notSupported();
+    public synchronized <T> T getObject(int columnIndex, Class<T> type) throws SQLException {
+        checkIsOpen();
+        if (type == null) {
+            throw con.createCUBRIDException(
+                    CUBRIDJDBCErrorCode.invalid_value, CUBRIDException.nullTypeMessage(), null);
+        }
+
+        if (type == String.class) {
+            return type.cast(getString(columnIndex));
+        }
+        if (type == BigDecimal.class) {
+            return type.cast(getBigDecimal(columnIndex));
+        }
+        if (type == byte[].class) {
+            return type.cast(getBytes(columnIndex));
+        }
+        if (type == Date.class) {
+            return type.cast(getDate(columnIndex));
+        }
+        if (type == Time.class) {
+            return type.cast(getTime(columnIndex));
+        }
+        if (type == Timestamp.class) {
+            return type.cast(getTimestamp(columnIndex));
+        }
+        if (type == Blob.class) {
+            return type.cast(getBlob(columnIndex));
+        }
+        if (type == Clob.class) {
+            return type.cast(getClob(columnIndex));
+        }
+
+        if (type == Boolean.class) {
+            boolean value = getBoolean(columnIndex);
+            return wasNull() ? null : type.cast(value);
+        }
+        if (type == Byte.class) {
+            byte value = getByte(columnIndex);
+            return wasNull() ? null : type.cast(value);
+        }
+        if (type == Short.class) {
+            short value = getShort(columnIndex);
+            return wasNull() ? null : type.cast(value);
+        }
+        if (type == Integer.class) {
+            int value = getInt(columnIndex);
+            return wasNull() ? null : type.cast(value);
+        }
+        if (type == Long.class) {
+            long value = getLong(columnIndex);
+            return wasNull() ? null : type.cast(value);
+        }
+        if (type == Float.class) {
+            float value = getFloat(columnIndex);
+            return wasNull() ? null : type.cast(value);
+        }
+        if (type == Double.class) {
+            double value = getDouble(columnIndex);
+            return wasNull() ? null : type.cast(value);
+        }
+
+        throw con.createCUBRIDException(
+                CUBRIDJDBCErrorCode.invalid_value,
+                CUBRIDException.cannotConvertMessage(type),
+                null);
     }
 
     /* JDK 1.7 */
-    public <T> T getObject(String columnLabel, Class<T> type) throws SQLException {
-        throw CUBRIDException.notSupported();
+    public synchronized <T> T getObject(String columnLabel, Class<T> type) throws SQLException {
+        return getObject(findColumn(columnLabel), type);
     }
 
     // ------------------------- JDBC 4.2 -----------------------------------

--- a/src/jdbc/cubrid/jdbc/driver/CUBRIDResultSet.java
+++ b/src/jdbc/cubrid/jdbc/driver/CUBRIDResultSet.java
@@ -63,10 +63,12 @@ import java.sql.Timestamp;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.Locale;
 import java.util.Map;
 import java.util.TimeZone;
 
@@ -76,6 +78,13 @@ import java.util.TimeZone;
  * @version 2.0
  */
 public class CUBRIDResultSet implements ResultSet {
+    private static final DateTimeFormatter DATE_LITERAL =
+            DateTimeFormatter.ofPattern("MM/dd/uuuu", Locale.ROOT);
+    private static final DateTimeFormatter TIME_LITERAL =
+            DateTimeFormatter.ofPattern("HH:mm:ss", Locale.ROOT);
+    private static final DateTimeFormatter DATETIME_LITERAL =
+            DateTimeFormatter.ofPattern("MM/dd/uuuu HH:mm:ss.SSS", Locale.ROOT);
+
     public boolean complete_on_close;
 
     private CUBRIDConnection con;
@@ -1847,7 +1856,13 @@ public class CUBRIDResultSet implements ResultSet {
         }
 
         String strvalue = null;
-        if (value instanceof java.sql.Time) {
+        if (value instanceof LocalTime) {
+            strvalue = "'" + TIME_LITERAL.format((LocalTime) value) + "'";
+        } else if (value instanceof LocalDate) {
+            strvalue = "'" + DATE_LITERAL.format((LocalDate) value) + "'";
+        } else if (value instanceof LocalDateTime) {
+            strvalue = "'" + DATETIME_LITERAL.format((LocalDateTime) value) + "'";
+        } else if (value instanceof java.sql.Time) {
             java.text.SimpleDateFormat format = new java.text.SimpleDateFormat("HH:mm:ss");
             strvalue = "'" + format.format((java.util.Date) value) + "'";
         } else if (value instanceof java.sql.Date) {

--- a/src/jdbc/cubrid/jdbc/driver/CUBRIDResultSet.java
+++ b/src/jdbc/cubrid/jdbc/driver/CUBRIDResultSet.java
@@ -35,6 +35,7 @@ import cubrid.jdbc.jci.UColumnInfo;
 import cubrid.jdbc.jci.UError;
 import cubrid.jdbc.jci.UErrorCode;
 import cubrid.jdbc.jci.UStatement;
+import cubrid.jdbc.jci.UUType;
 import cubrid.sql.CUBRIDOID;
 import java.io.Closeable;
 import java.io.IOException;
@@ -59,6 +60,9 @@ import java.sql.SQLXML;
 import java.sql.Statement;
 import java.sql.Time;
 import java.sql.Timestamp;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.HashMap;
@@ -1678,6 +1682,76 @@ public class CUBRIDResultSet implements ResultSet {
         }
     }
 
+    private LocalDate getLocalDate(int columnIndex) throws SQLException {
+        checkJavaTimeColumn(columnIndex, LocalDate.class);
+
+        LocalDate value;
+        synchronized (u_stmt) {
+            value = u_stmt.getLocalDate(columnIndex - 1);
+            error = u_stmt.getRecentError();
+        }
+
+        checkGetXXXError();
+        return value;
+    }
+
+    private LocalTime getLocalTime(int columnIndex) throws SQLException {
+        checkJavaTimeColumn(columnIndex, LocalTime.class);
+
+        LocalTime value;
+        synchronized (u_stmt) {
+            value = u_stmt.getLocalTime(columnIndex - 1);
+            error = u_stmt.getRecentError();
+        }
+
+        checkGetXXXError();
+        return value;
+    }
+
+    private LocalDateTime getLocalDateTime(int columnIndex) throws SQLException {
+        checkJavaTimeColumn(columnIndex, LocalDateTime.class);
+
+        LocalDateTime value;
+        synchronized (u_stmt) {
+            value = u_stmt.getLocalDateTime(columnIndex - 1);
+            error = u_stmt.getRecentError();
+        }
+
+        checkGetXXXError();
+        return value;
+    }
+
+    private void checkJavaTimeColumn(int columnIndex, Class<?> type) throws SQLException {
+        checkRowIsValidForGet();
+        checkColumnIsValid(columnIndex);
+
+        if (isJavaTimeConversionSupported(column_info[columnIndex - 1].getColumnType(), type)) {
+            return;
+        }
+
+        throw con.createCUBRIDException(
+                CUBRIDJDBCErrorCode.invalid_value,
+                CUBRIDException.cannotConvertMessage(type),
+                null);
+    }
+
+    private static boolean isJavaTimeConversionSupported(byte columnType, Class<?> type) {
+        switch (columnType) {
+            case UUType.U_TYPE_DATE:
+                return type == LocalDate.class || type == LocalDateTime.class;
+            case UUType.U_TYPE_TIME:
+                return type == LocalTime.class || type == LocalDateTime.class;
+            case UUType.U_TYPE_TIMESTAMP:
+            case UUType.U_TYPE_DATETIME:
+                return true;
+            case UUType.U_TYPE_NULL:
+                /* The server did not declare a type, so the decoded value carries its own. */
+                return true;
+            default:
+                return false;
+        }
+    }
+
     private void beforeGetValue(int columnIndex) throws SQLException {
         checkRowIsValidForGet();
         checkColumnIsValid(columnIndex);
@@ -2179,6 +2253,16 @@ public class CUBRIDResultSet implements ResultSet {
         if (type == Double.class) {
             double value = getDouble(columnIndex);
             return wasNull() ? null : type.cast(value);
+        }
+
+        if (type == LocalDate.class) {
+            return type.cast(getLocalDate(columnIndex));
+        }
+        if (type == LocalTime.class) {
+            return type.cast(getLocalTime(columnIndex));
+        }
+        if (type == LocalDateTime.class) {
+            return type.cast(getLocalDateTime(columnIndex));
         }
 
         throw con.createCUBRIDException(

--- a/src/jdbc/cubrid/jdbc/driver/CUBRIDResultSet.java
+++ b/src/jdbc/cubrid/jdbc/driver/CUBRIDResultSet.java
@@ -1789,6 +1789,11 @@ public class CUBRIDResultSet implements ResultSet {
         checkColumnIsValid(columnIndex);
         checkColumnIsUpdatable(columnIndex);
 
+        if (CUBRIDPreparedStatement.isUnsupportedJavaTime(value)) {
+            throw CUBRIDException.notSupported(
+                    CUBRIDException.cannotStoreMessage(value.getClass()));
+        }
+
         updates[columnIndex - 1] = value;
         if (updated[columnIndex - 1] == false) {
             updated[columnIndex - 1] = true;

--- a/src/jdbc/cubrid/jdbc/jci/UDateTimeFields.java
+++ b/src/jdbc/cubrid/jdbc/jci/UDateTimeFields.java
@@ -34,6 +34,9 @@ package cubrid.jdbc.jci;
 import cubrid.sql.CUBRIDTimestamp;
 import java.sql.Date;
 import java.sql.Time;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 
 /**
  * A date or time value as the server sent it, holding both the calendar fields and the epoch the
@@ -46,6 +49,9 @@ import java.sql.Time;
  * keep their old behaviour.
  */
 final class UDateTimeFields {
+    private static final int NANOS_PER_MILLI = 1000000;
+    static final LocalDate TIME_BASE_DATE = LocalDate.of(1970, 1, 1);
+
     private final byte type;
     private final long epoch;
     private final int year;
@@ -108,6 +114,10 @@ final class UDateTimeFields {
         return type != UUType.U_TYPE_TIME;
     }
 
+    private boolean hasTime() {
+        return type != UUType.U_TYPE_DATE;
+    }
+
     private boolean isZeroDate() {
         return hasDate() && year == 0 && month == 0 && day == 0;
     }
@@ -128,5 +138,29 @@ final class UDateTimeFields {
             default:
                 return new CUBRIDTimestamp(epoch, CUBRIDTimestamp.DATETIME);
         }
+    }
+
+    LocalDate toLocalDate() throws UJciException {
+        if (!hasDate()) {
+            throw new UJciException(UErrorCode.ER_TYPE_CONVERSION);
+        }
+        return isZeroDate() ? null : LocalDate.of(year, month, day);
+    }
+
+    LocalTime toLocalTime() throws UJciException {
+        if (!hasTime()) {
+            throw new UJciException(UErrorCode.ER_TYPE_CONVERSION);
+        }
+        return LocalTime.of(hour, minute, second, millisecond * NANOS_PER_MILLI);
+    }
+
+    LocalDateTime toLocalDateTime() throws UJciException {
+        if (!hasDate()) {
+            return LocalDateTime.of(TIME_BASE_DATE, toLocalTime());
+        }
+        return isZeroDate()
+                ? null
+                : LocalDateTime.of(
+                        year, month, day, hour, minute, second, millisecond * NANOS_PER_MILLI);
     }
 }

--- a/src/jdbc/cubrid/jdbc/jci/UDateTimeFields.java
+++ b/src/jdbc/cubrid/jdbc/jci/UDateTimeFields.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (C) 2008 Search Solution Corporation.
+ * Copyright (c) 2016 CUBRID Corporation.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * - Neither the name of the <ORGANIZATION> nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ */
+
+package cubrid.jdbc.jci;
+
+import cubrid.sql.CUBRIDTimestamp;
+import java.sql.Date;
+import java.sql.Time;
+
+/**
+ * A date or time value as the server sent it, holding both the calendar fields and the epoch the
+ * reader computed from them.
+ *
+ * <p>The wire carries year, month, day, hour, minute and second with no time zone. Rebuilding those
+ * fields from an epoch applies the JVM default time zone a second time, which shifts values that do
+ * not exist in that zone, so the fields are kept as they arrived and the java.time getters read
+ * them directly. The epoch is kept as well because the java.sql getters answer with it and have to
+ * keep their old behaviour.
+ */
+final class UDateTimeFields {
+    private final byte type;
+    private final long epoch;
+    private final int year;
+    private final int month;
+    private final int day;
+    private final int hour;
+    private final int minute;
+    private final int second;
+    private final int millisecond;
+
+    private UDateTimeFields(
+            byte type,
+            long epoch,
+            int year,
+            int month,
+            int day,
+            int hour,
+            int minute,
+            int second,
+            int millisecond) {
+        this.type = type;
+        this.epoch = epoch;
+        this.year = year;
+        this.month = month;
+        this.day = day;
+        this.hour = hour;
+        this.minute = minute;
+        this.second = second;
+        this.millisecond = millisecond;
+    }
+
+    static UDateTimeFields ofDate(long epoch, int year, int month, int day) {
+        return new UDateTimeFields(UUType.U_TYPE_DATE, epoch, year, month, day, 0, 0, 0, 0);
+    }
+
+    static UDateTimeFields ofTime(long epoch, int hour, int minute, int second) {
+        return new UDateTimeFields(UUType.U_TYPE_TIME, epoch, 0, 0, 0, hour, minute, second, 0);
+    }
+
+    static UDateTimeFields ofTimestamp(
+            long epoch, int year, int month, int day, int hour, int minute, int second) {
+        return new UDateTimeFields(
+                UUType.U_TYPE_TIMESTAMP, epoch, year, month, day, hour, minute, second, 0);
+    }
+
+    static UDateTimeFields ofDatetime(
+            long epoch,
+            int year,
+            int month,
+            int day,
+            int hour,
+            int minute,
+            int second,
+            int millisecond) {
+        return new UDateTimeFields(
+                UUType.U_TYPE_DATETIME, epoch, year, month, day, hour, minute, second, millisecond);
+    }
+
+    private boolean hasDate() {
+        return type != UUType.U_TYPE_TIME;
+    }
+
+    private boolean isZeroDate() {
+        return hasDate() && year == 0 && month == 0 && day == 0;
+    }
+
+    /* Answers the java.sql value when o carries wire fields, and o itself otherwise. */
+    static Object sqlValueOf(Object o) {
+        return o instanceof UDateTimeFields ? ((UDateTimeFields) o).toSqlValue() : o;
+    }
+
+    private Object toSqlValue() {
+        switch (type) {
+            case UUType.U_TYPE_DATE:
+                return new Date(epoch);
+            case UUType.U_TYPE_TIME:
+                return new Time(epoch);
+            case UUType.U_TYPE_TIMESTAMP:
+                return new CUBRIDTimestamp(epoch, CUBRIDTimestamp.TIMESTAMP);
+            default:
+                return new CUBRIDTimestamp(epoch, CUBRIDTimestamp.DATETIME);
+        }
+    }
+}

--- a/src/jdbc/cubrid/jdbc/jci/UDateTimeFields.java
+++ b/src/jdbc/cubrid/jdbc/jci/UDateTimeFields.java
@@ -51,6 +51,8 @@ import java.time.LocalTime;
 final class UDateTimeFields {
     private static final int NANOS_PER_MILLI = 1000000;
     static final LocalDate TIME_BASE_DATE = LocalDate.of(1970, 1, 1);
+    private static final LocalDateTime ROUNDED_DATETIME = LocalDateTime.of(1, 1, 1, 0, 0, 0);
+    private static final LocalDateTime ROUNDED_TIMESTAMP = LocalDateTime.of(1970, 1, 1, 0, 0, 0);
 
     private final byte type;
     private final long epoch;
@@ -140,27 +142,34 @@ final class UDateTimeFields {
         }
     }
 
+    private LocalDateTime roundedZeroDate() {
+        return type == UUType.U_TYPE_TIMESTAMP ? ROUNDED_TIMESTAMP : ROUNDED_DATETIME;
+    }
+
     LocalDate toLocalDate() throws UJciException {
         if (!hasDate()) {
             throw new UJciException(UErrorCode.ER_TYPE_CONVERSION);
         }
-        return isZeroDate() ? null : LocalDate.of(year, month, day);
+        return isZeroDate() ? roundedZeroDate().toLocalDate() : LocalDate.of(year, month, day);
     }
 
     LocalTime toLocalTime() throws UJciException {
         if (!hasTime()) {
             throw new UJciException(UErrorCode.ER_TYPE_CONVERSION);
         }
-        return LocalTime.of(hour, minute, second, millisecond * NANOS_PER_MILLI);
+        return isZeroDate()
+                ? roundedZeroDate().toLocalTime()
+                : LocalTime.of(hour, minute, second, millisecond * NANOS_PER_MILLI);
     }
 
     LocalDateTime toLocalDateTime() throws UJciException {
         if (!hasDate()) {
             return LocalDateTime.of(TIME_BASE_DATE, toLocalTime());
         }
-        return isZeroDate()
-                ? null
-                : LocalDateTime.of(
-                        year, month, day, hour, minute, second, millisecond * NANOS_PER_MILLI);
+        if (isZeroDate()) {
+            return roundedZeroDate();
+        }
+        return LocalDateTime.of(
+                year, month, day, hour, minute, second, millisecond * NANOS_PER_MILLI);
     }
 }

--- a/src/jdbc/cubrid/jdbc/jci/UGetTypeConvertedValue.java
+++ b/src/jdbc/cubrid/jdbc/jci/UGetTypeConvertedValue.java
@@ -54,8 +54,19 @@ import java.sql.Clob;
 import java.sql.Date;
 import java.sql.Time;
 import java.sql.Timestamp;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
 
 public abstract class UGetTypeConvertedValue {
+    private static final DateTimeFormatter DATE_FORMAT =
+            DateTimeFormatter.ofPattern("uuuu-MM-dd", Locale.ROOT);
+    private static final DateTimeFormatter TIME_FORMAT =
+            DateTimeFormatter.ofPattern("HH:mm:ss", Locale.ROOT);
+    private static final DateTimeFormatter DATETIME_FORMAT =
+            DateTimeFormatter.ofPattern("uuuu-MM-dd HH:mm:ss.SSS", Locale.ROOT);
 
     public static BigDecimal getBigDecimal(Object data) throws UJciException {
         if (data == null) return null;
@@ -252,6 +263,12 @@ public abstract class UGetTypeConvertedValue {
             java.text.SimpleDateFormat f = new java.text.SimpleDateFormat(form);
 
             return f.format(data);
+        } else if (data instanceof LocalDate) {
+            return DATE_FORMAT.format((LocalDate) data);
+        } else if (data instanceof LocalTime) {
+            return TIME_FORMAT.format((LocalTime) data);
+        } else if (data instanceof LocalDateTime) {
+            return DATETIME_FORMAT.format((LocalDateTime) data);
         } else if (data instanceof CUBRIDOID) {
             try {
                 return ((CUBRIDOID) data).getOidString();

--- a/src/jdbc/cubrid/jdbc/jci/UInputBuffer.java
+++ b/src/jdbc/cubrid/jdbc/jci/UInputBuffer.java
@@ -50,8 +50,6 @@ import cubrid.sql.CUBRIDOIDImpl;
 import cubrid.sql.CUBRIDTimestamp;
 import cubrid.sql.CUBRIDTimestamptz;
 import java.io.IOException;
-import java.sql.Date;
-import java.sql.Time;
 import java.util.Calendar;
 import java.util.TimeZone;
 
@@ -313,7 +311,7 @@ class UInputBuffer {
         return stringData;
     }
 
-    Date readDate() throws UJciException {
+    UDateTimeFields readDate() throws UJciException {
         int year, month, day;
         year = readShort();
         month = readShort();
@@ -337,10 +335,10 @@ class UInputBuffer {
         }
         cal.set(Calendar.MILLISECOND, 0);
 
-        return new Date(cal.getTimeInMillis());
+        return UDateTimeFields.ofDate(cal.getTimeInMillis(), year, month, day);
     }
 
-    Time readTime() throws UJciException {
+    UDateTimeFields readTime() throws UJciException {
         int hour, minute, second;
         hour = readShort();
         minute = readShort();
@@ -350,10 +348,14 @@ class UInputBuffer {
         cal.set(1970, 0, 1, hour, minute, second);
         cal.set(Calendar.MILLISECOND, 0);
 
-        return new Time(cal.getTimeInMillis());
+        return UDateTimeFields.ofTime(cal.getTimeInMillis(), hour, minute, second);
     }
 
-    CUBRIDTimestamp readTimestamp(boolean is_tz) throws UJciException {
+    private CUBRIDTimestamp readTimestamp(boolean is_tz) throws UJciException {
+        return (CUBRIDTimestamp) UDateTimeFields.sqlValueOf(readTimestampFields(is_tz));
+    }
+
+    UDateTimeFields readTimestampFields(boolean is_tz) throws UJciException {
         int year, month, day, hour, minute, second;
         year = readShort();
         month = readShort();
@@ -383,7 +385,8 @@ class UInputBuffer {
         }
         cal.set(Calendar.MILLISECOND, 0);
 
-        return new CUBRIDTimestamp(cal.getTimeInMillis(), CUBRIDTimestamp.TIMESTAMP);
+        return UDateTimeFields.ofTimestamp(
+                cal.getTimeInMillis(), year, month, day, hour, minute, second);
     }
 
     CUBRIDTimestamptz readTimestamptz(int size) throws UJciException {
@@ -412,7 +415,11 @@ class UInputBuffer {
         return CUBRIDTimestamptz.valueOf(cubrid_ts, timezone);
     }
 
-    CUBRIDTimestamp readDatetime(boolean is_tz) throws UJciException {
+    private CUBRIDTimestamp readDatetime(boolean is_tz) throws UJciException {
+        return (CUBRIDTimestamp) UDateTimeFields.sqlValueOf(readDatetimeFields(is_tz));
+    }
+
+    UDateTimeFields readDatetimeFields(boolean is_tz) throws UJciException {
         int year, month, day, hour, minute, second, millisecond;
         year = readShort();
         month = readShort();
@@ -443,7 +450,8 @@ class UInputBuffer {
         }
         cal.set(Calendar.MILLISECOND, millisecond);
 
-        return new CUBRIDTimestamp(cal.getTimeInMillis(), CUBRIDTimestamp.DATETIME);
+        return UDateTimeFields.ofDatetime(
+                cal.getTimeInMillis(), year, month, day, hour, minute, second, millisecond);
     }
 
     CUBRIDTimestamptz readDatetimetz(int size) throws UJciException {

--- a/src/jdbc/cubrid/jdbc/jci/UOutputBuffer.java
+++ b/src/jdbc/cubrid/jdbc/jci/UOutputBuffer.java
@@ -52,11 +52,16 @@ import java.io.OutputStream;
 import java.sql.Date;
 import java.sql.Time;
 import java.sql.Timestamp;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.Calendar;
 import java.util.TimeZone;
 import javax.transaction.xa.Xid;
 
 class UOutputBuffer {
+    private static final int NANOS_PER_MILLI = 1000000;
+
     private UConnection u_con;
     private OutputStream output;
     private ByteArrayBuffer dataBuffer;
@@ -178,6 +183,54 @@ class UOutputBuffer {
         dataBuffer.writeShort((short) 0);
         dataBuffer.writeShort((short) 0);
         dataBuffer.writeShort((short) 0);
+    }
+
+    int addDate(LocalDate value) throws IOException {
+        dataBuffer.writeInt(14);
+        dataBuffer.writeShort(value.getYear());
+        dataBuffer.writeShort(value.getMonthValue());
+        dataBuffer.writeShort(value.getDayOfMonth());
+        dataBuffer.writeShort((short) 0);
+        dataBuffer.writeShort((short) 0);
+        dataBuffer.writeShort((short) 0);
+        dataBuffer.writeShort((short) 0);
+        return 18;
+    }
+
+    int addTimestamp(LocalDateTime value) throws IOException {
+        dataBuffer.writeInt(14);
+        dataBuffer.writeShort(value.getYear());
+        dataBuffer.writeShort(value.getMonthValue());
+        dataBuffer.writeShort(value.getDayOfMonth());
+        dataBuffer.writeShort(value.getHour());
+        dataBuffer.writeShort(value.getMinute());
+        dataBuffer.writeShort(value.getSecond());
+        dataBuffer.writeShort((short) 0);
+        return 18;
+    }
+
+    int addTime(LocalTime value) throws IOException {
+        dataBuffer.writeInt(14);
+        dataBuffer.writeShort((short) 0);
+        dataBuffer.writeShort((short) 0);
+        dataBuffer.writeShort((short) 0);
+        dataBuffer.writeShort(value.getHour());
+        dataBuffer.writeShort(value.getMinute());
+        dataBuffer.writeShort(value.getSecond());
+        dataBuffer.writeShort((short) 0);
+        return 18;
+    }
+
+    int addDatetime(LocalDateTime value) throws IOException {
+        dataBuffer.writeInt(14);
+        dataBuffer.writeShort(value.getYear());
+        dataBuffer.writeShort(value.getMonthValue());
+        dataBuffer.writeShort(value.getDayOfMonth());
+        dataBuffer.writeShort(value.getHour());
+        dataBuffer.writeShort(value.getMinute());
+        dataBuffer.writeShort(value.getSecond());
+        dataBuffer.writeShort(value.getNano() / NANOS_PER_MILLI);
+        return 18;
     }
 
     int addTime(Time value) throws IOException {
@@ -374,12 +427,20 @@ class UOutputBuffer {
             case UUType.U_TYPE_DATE:
                 if (value == null) {
                     return addDate(UGetTypeConvertedValue.getDate(new Timestamp(0)));
+                } else if (value instanceof LocalDate) {
+                    return addDate((LocalDate) value);
+                } else if (value instanceof LocalDateTime) {
+                    return addDate(((LocalDateTime) value).toLocalDate());
                 } else {
                     return addDate(UGetTypeConvertedValue.getDate(value));
                 }
             case UUType.U_TYPE_TIME:
                 if (value == null) {
                     return addTime(UGetTypeConvertedValue.getTime(new Timestamp(0)));
+                } else if (value instanceof LocalTime) {
+                    return addTime((LocalTime) value);
+                } else if (value instanceof LocalDateTime) {
+                    return addTime(((LocalDateTime) value).toLocalTime());
                 } else {
                     return addTime(UGetTypeConvertedValue.getTime(value));
                 }
@@ -387,6 +448,12 @@ class UOutputBuffer {
             case UUType.U_TYPE_TIMESTAMP:
                 if (value == null) {
                     return addTimestamp(UGetTypeConvertedValue.getTimestamp(new Timestamp(0)));
+                } else if (value instanceof LocalDateTime) {
+                    return addTimestamp((LocalDateTime) value);
+                } else if (value instanceof LocalDate) {
+                    return addTimestamp(((LocalDate) value).atStartOfDay());
+                } else if (value instanceof LocalTime) {
+                    return addTimestamp(((LocalTime) value).atDate(UDateTimeFields.TIME_BASE_DATE));
                 } else {
                     return addTimestamp(UGetTypeConvertedValue.getTimestamp(value));
                 }
@@ -402,6 +469,12 @@ class UOutputBuffer {
             case UUType.U_TYPE_DATETIME:
                 if (value == null) {
                     return addDatetime(UGetTypeConvertedValue.getTimestamp(new Timestamp(0)));
+                } else if (value instanceof LocalDateTime) {
+                    return addDatetime((LocalDateTime) value);
+                } else if (value instanceof LocalDate) {
+                    return addDatetime(((LocalDate) value).atStartOfDay());
+                } else if (value instanceof LocalTime) {
+                    return addDatetime(((LocalTime) value).atDate(UDateTimeFields.TIME_BASE_DATE));
                 } else {
                     return addDatetime(UGetTypeConvertedValue.getTimestamp(value));
                 }

--- a/src/jdbc/cubrid/jdbc/jci/UStatement.java
+++ b/src/jdbc/cubrid/jdbc/jci/UStatement.java
@@ -55,6 +55,9 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Time;
 import java.sql.Timestamp;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.HashMap;
 
@@ -1346,6 +1349,76 @@ public class UStatement {
         } catch (UJciException e) {
             e.toUError(errorHandler);
         }
+        return null;
+    }
+
+    public synchronized LocalDate getLocalDate(int index) {
+        UDateTimeFields fields = dateTimeFieldsOf(index);
+        if (fields == null) return null;
+
+        try {
+            return fields.toLocalDate();
+        } catch (UJciException e) {
+            e.toUError(errorHandler);
+        }
+        return null;
+    }
+
+    public synchronized LocalTime getLocalTime(int index) {
+        UDateTimeFields fields = dateTimeFieldsOf(index);
+        if (fields == null) return null;
+
+        try {
+            return fields.toLocalTime();
+        } catch (UJciException e) {
+            e.toUError(errorHandler);
+        }
+        return null;
+    }
+
+    public synchronized LocalDateTime getLocalDateTime(int index) {
+        UDateTimeFields fields = dateTimeFieldsOf(index);
+        if (fields == null) return null;
+
+        try {
+            return fields.toLocalDateTime();
+        } catch (UJciException e) {
+            e.toUError(errorHandler);
+        }
+        return null;
+    }
+
+    private UDateTimeFields dateTimeFieldsOf(int index) {
+        errorHandler = new UError(relatedConnection);
+
+        if (isClosed == true) {
+            errorHandler.setErrorCode(UErrorCode.ER_IS_CLOSED);
+            return null;
+        }
+        if (index < 0 || index >= columnNumber) {
+            errorHandler.setErrorCode(UErrorCode.ER_COLUMN_INDEX);
+            return null;
+        }
+        if (checkReFetch() != true) return null;
+        if (fetchedTupleNumber <= 0) {
+            errorHandler.setErrorCode(UErrorCode.ER_NO_MORE_DATA);
+            return null;
+        }
+
+        Object obj;
+        if ((tuples == null)
+                || (tuples[cursorPosition - currentFirstCursor] == null)
+                || ((obj = tuples[cursorPosition - currentFirstCursor].getAttribute(index))
+                        == null)) {
+            errorHandler.setErrorCode(UErrorCode.ER_WAS_NULL);
+            return null;
+        }
+
+        if (obj instanceof UDateTimeFields) {
+            return (UDateTimeFields) obj;
+        }
+
+        errorHandler.setErrorCode(UErrorCode.ER_TYPE_CONVERSION);
         return null;
     }
 

--- a/src/jdbc/cubrid/jdbc/jci/UStatement.java
+++ b/src/jdbc/cubrid/jdbc/jci/UStatement.java
@@ -438,6 +438,18 @@ public class UStatement {
         bindValue(index, UUType.U_TYPE_VARBIT, data);
     }
 
+    public void bind(int index, LocalDate value) {
+        bindValue(index, UUType.U_TYPE_DATE, value);
+    }
+
+    public void bind(int index, LocalTime value) {
+        bindValue(index, UUType.U_TYPE_TIME, value);
+    }
+
+    public void bind(int index, LocalDateTime value) {
+        bindValue(index, UUType.U_TYPE_DATETIME, value);
+    }
+
     public void bind(int index, Date value) {
         bindValue(index, UUType.U_TYPE_DATE, value);
     }

--- a/src/jdbc/cubrid/jdbc/jci/UStatement.java
+++ b/src/jdbc/cubrid/jdbc/jci/UStatement.java
@@ -2035,7 +2035,7 @@ public class UStatement {
             return null;
         }
 
-        return obj;
+        return UDateTimeFields.sqlValueOf(obj);
     }
 
     private boolean checkReFetch() {
@@ -2232,12 +2232,12 @@ public class UStatement {
             case UUType.U_TYPE_TIME:
                 return inBuffer.readTime();
             case UUType.U_TYPE_TIMESTAMP:
-                return inBuffer.readTimestamp(false);
+                return inBuffer.readTimestampFields(false);
             case UUType.U_TYPE_TIMESTAMPTZ:
             case UUType.U_TYPE_TIMESTAMPLTZ:
                 return inBuffer.readTimestamptz(dataSize);
             case UUType.U_TYPE_DATETIME:
-                return inBuffer.readDatetime(false);
+                return inBuffer.readDatetimeFields(false);
             case UUType.U_TYPE_DATETIMETZ:
             case UUType.U_TYPE_DATETIMELTZ:
                 return inBuffer.readDatetimetz(dataSize);
@@ -2255,7 +2255,9 @@ public class UStatement {
                         if (eleSize <= 0) aArray.setElement(i, null);
                         else
                             aArray.setElement(
-                                    i, readData(inBuffer, baseType, eleSize, charsetName));
+                                    i,
+                                    UDateTimeFields.sqlValueOf(
+                                            readData(inBuffer, baseType, eleSize, charsetName)));
                     }
                     return aArray;
                 }


### PR DESCRIPTION
<http://jira.cubrid.org/browse/APIS-1107>

### Purpose
java.time의 LocalDate, LocalTime, LocalDateTime을 지원하도록 개선합니다.

### Implementation
날짜를 epoch(Unix Time)으로 변환하지 않고, 서버가 준 년/월/일 필드를 그대로 사용합니다. epoch는 시간대가 있어야 해석되므로 LocalDate, LocalTime, LocalDateTime 지원을 위해서는 기존 epoch로 변환하는 코드를 사용하지 않아야 합니다.

- 읽기: jci에 값 객체 `UDateTimeFields`를 두고, 날짜 리더가 java.sql 대신 이 객체를 만듭니다. 튜플에서 값을 꺼내는 `beforeGetXXX` 한 곳에서 java.sql로 되돌리므로 기존 getter는 건드리지 않았습니다.
- 쓰기: `UOutputBuffer`에 필드를 그대로 싣는 인코더를 추가했습니다.
- 적용 대상은 CUBRIDResultSet, CUBRIDCallableStatement(OUT 파라미터)입니다.

읽기: getObject(int, Class<T>)
| 컬럼 | LocalDate | LocalTime | LocalDateTime |
| --- | --- | --- | --- |
| DATE | O | 거부 | O |
| TIME | 거부 | O | O |
| TIMESTAMP, DATETIME | O | O | O |

쓰기: setObject, updateObject, updateRow
| 컬럼 | LocalDate | LocalTime | LocalDateTime |
| --- | --- | --- | --- |
| DATE | O | 거부 | O |
| TIME | 거부 | O | O |
| TIMESTAMP, DATETIME | O | O | O |
| CHAR, VARCHAR, NCHAR, NCHAR VARYING | O | O | O |

### Remarks
 - 이번 PR에서는 TZ 계열은 제외합니다.
 - https://github.com/CUBRID/cubrid-testcases-private/pull/1645
