### PR TITLE
[APIS-1113] Inclusion of session token in JDBC driver query-cancel

### DIFF
--- a/src/jdbc/cubrid/jdbc/jci/UConnection.java
+++ b/src/jdbc/cubrid/jdbc/jci/UConnection.java
@@ -108,15 +108,26 @@ public abstract class UConnection {
 
     public static final int PROTOCOL_V11 = 11;
     public static final int PROTOCOL_V12 = 12;
+    /* CAS-issued session id required (not just optionally checked) for QC/X1 query cancel,
+     * see KVE-2026-1827 and engine ticket CBRD-27389. Mirrors src/broker/cas_protocol.h's
+     * PROTOCOL_V13 (engine) and src/cci/broker_cas_protocol.h's PROTOCOL_V13 (CCI). */
+    public static final int PROTOCOL_V13 = 13;
 
     /* Current protocol version */
-    protected static final byte CAS_PROTOCOL_VERSION = PROTOCOL_V12;
+    protected static final byte CAS_PROTOCOL_VERSION = PROTOCOL_V13;
     protected static final byte CAS_PROTO_INDICATOR = 0x40;
     protected static final byte CAS_PROTO_VER_MASK = 0x3F;
     protected static final byte CAS_RENEWED_ERROR_CODE = (byte) 0x80;
     protected static final byte CAS_SUPPORT_HOLDABLE_RESULT = (byte) 0x40;
     /* Do not remove and rename CAS_RECONNECT_WHEN_SERVER_DOWN */
     protected static final byte CAS_RECONNECT_WHEN_SERVER_DOWN = (byte) 0x20;
+    /* Announces that a 4-byte CAS-issued session id is appended after the standard 10-byte
+     * query-cancel header sent to BrokerHandler.cancelBroker's "X1" request, so the broker can
+     * verify the cancel request against the session id in addition to source IP/port. This bit
+     * only controls wire framing on that one (unauthenticated) cancel request; whether the check
+     * is actually mandatory is decided by the broker from this connection's own CAS_PROTOCOL_VERSION
+     * (PROTOCOL_V13 or later), recorded at connect time, not from this bit. */
+    public static final byte CAS_SUPPORT_SESSION_CANCEL = (byte) 0x10;
 
     protected static final byte CAS_ORACLE_COMPAT_NUMBER_BEHAVIOR = (byte) 0x01;
 
@@ -1387,7 +1398,10 @@ public abstract class UConnection {
     }
 
     void cancel() throws UJciException, IOException {
-        BrokerHandler.cancelBroker(casIp, casPort, casProcessId, READ_TIMEOUT);
+        byte[] session = new byte[4];
+        for (int i = 0; i < 4; i++) session[i] = sessionId[i + 8];
+
+        BrokerHandler.cancelBroker(casIp, casPort, casProcessId, session, READ_TIMEOUT);
     }
 
     /*

--- a/src/jdbc/cubrid/jdbc/net/BrokerHandler.java
+++ b/src/jdbc/cubrid/jdbc/net/BrokerHandler.java
@@ -285,17 +285,20 @@ public class BrokerHandler {
         return status;
     }
 
-    public static void cancelBroker(String ip, int port, int process, int timeout)
+    public static void cancelBroker(String ip, int port, int process, byte[] session, int timeout)
             throws IOException, UJciException {
-        ByteArrayOutputStream bao = new ByteArrayOutputStream(10);
+        ByteArrayOutputStream bao = new ByteArrayOutputStream(14);
         DataOutputStream dao = new DataOutputStream(bao);
         dao.write('X');
         dao.write('1');
         dao.write(UConnection.driverInfo[6]);
-        dao.write(UConnection.driverInfo[7]);
+        /* Set the session-cancel capability bit only on this cancel request, not on the shared
+         * driverInfo array used for the main connect handshake, matching cubrid-cci's approach. */
+        dao.write(UConnection.driverInfo[7] | UConnection.CAS_SUPPORT_SESSION_CANCEL);
         dao.write(UConnection.driverInfo[8]);
         dao.write(UConnection.driverInfo[9]);
         dao.writeInt(process);
+        dao.write(session);
 
         cancelRequest(ip, port, bao.toByteArray(), timeout);
     }


### PR DESCRIPTION
<http://jira.cubrid.org/browse/APIS-1113>

### Purpose

통신 프로토콜에 아래의 플래그를 추가
public static final byte CAS_SUPPORT_SESSION_CANCEL = (byte) 0x10;

프로토콜 버전 추가
public static final int PROTOCOL_V13 = 13;

### Implementation

 QC/X1 취소 요청에 세션ID를 실어 보내도록 확장
PROTOCOL_V13으로 변경

### Remarks
N/A
